### PR TITLE
Add unit tests for BookingService payload handling

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,7 @@
 # BFF runtime
 NODE_ENV=development
 PORT=3000
+TZ=UTC
 
 # JWT (required in non-local envs)
 JWT_SECRET=replace-with-a-strong-secret

--- a/src/api/services/booking.service.spec.ts
+++ b/src/api/services/booking.service.spec.ts
@@ -1,0 +1,37 @@
+import { BookingService } from './booking.service';
+
+describe('BFF BookingService', () => {
+  let service: BookingService;
+  const httpService = {
+    post: jest.fn(),
+    get: jest.fn(),
+    delete: jest.fn(),
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    service = new BookingService(httpService as any);
+  });
+
+  it('forwards booking payload without timestamp transformation', async () => {
+    const payload = {
+      data: [
+        {
+          id: 'booking-1',
+          startTime: '2026-06-10T11:00:00.000Z',
+          endTime: '2026-06-10T12:00:00.000Z',
+        },
+      ],
+      total: 1,
+      page: 1,
+      lastPage: 1,
+    };
+
+    httpService.get.mockResolvedValue(payload);
+
+    const result = await service.getAllBookings({ page: 1 }, 'jwt-token');
+
+    expect(result).toBe(payload);
+    expect(httpService.get).toHaveBeenCalledWith('bookings', { page: 1 }, 'jwt-token');
+  });
+});

--- a/src/api/services/booking.service.spec.ts
+++ b/src/api/services/booking.service.spec.ts
@@ -26,12 +26,13 @@ describe('BFF BookingService', () => {
       page: 1,
       lastPage: 1,
     };
+    const expectedResult = JSON.parse(JSON.stringify(payload));
 
     httpService.get.mockResolvedValue(payload);
 
     const result = await service.getAllBookings({ page: 1 }, 'jwt-token');
 
-    expect(result).toBe(payload);
+    expect(result).toEqual(expectedResult);
     expect(httpService.get).toHaveBeenCalledWith('bookings', { page: 1 }, 'jwt-token');
   });
 });


### PR DESCRIPTION
This pull request introduces a new unit test for the `BookingService` and a small environment configuration change. The most significant update is the addition of a test to ensure that booking payloads are forwarded without timestamp transformation.

**Testing improvements:**

* Added a new unit test for `BookingService` in `booking.service.spec.ts` to verify that the service forwards booking payloads without modifying timestamp fields.

**Configuration changes:**

* Set the timezone to UTC by adding `TZ=UTC` in `.env.example` to standardize environment behavior.…dling