### PR TITLE
Add WhatsApp settings management and improve type safety

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,12 @@ GrillRent BFF is a Backend-for-Frontend (BFF) built with [NestJS](https://nestjs
   - Management of resources like grills, courts, etc.
 - **Notices**:
   - Creation, update, and deletion of notices.
+- **Onboarding**:
+  - Resident onboarding endpoints and restricted-session guard enforcement.
+- **Messages**:
+  - Contact submit/admin inbox proxy endpoints.
+- **WhatsApp Settings**:
+  - Organization-scoped provider settings and group bindings.
 - **Bookings**:
   - Creation, retrieval, deletion, and availability checks for bookings.
 
@@ -75,6 +81,9 @@ src/
 - **POST** `/users/register`: Register a new user.
 - **POST** `/users/login`: Log in.
 - **GET** `/users/profile`: Get user profile.
+- **POST** `/users/onboarding/email`: Set onboarding email.
+- **POST** `/users/onboarding/verify`: Verify onboarding token.
+- **POST** `/users/onboarding/change-password`: Change temporary password.
 
 ### Resources
 - **POST** `/resources`: Create a resource.
@@ -85,8 +94,25 @@ src/
 ### Notices
 - **POST** `/notices`: Create a notice.
 - **GET** `/notices`: List all notices.
+- **GET** `/notices/unread-count`: Get unread state (`unreadCount`, `hasUnread`, `lastSeenNoticesAt`).
+- **POST** `/notices/mark-seen`: Mark notices as seen.
 - **PUT** `/notices/:id`: Update a notice.
 - **DELETE** `/notices/:id`: Delete a notice.
+
+### Messages
+- **POST** `/messages/contact`: Submit contact message.
+- **GET** `/messages/admin`: List messages for admin inbox.
+- **GET** `/messages/unread-count`: Get admin unread state.
+- **POST** `/messages/:id/mark-read`: Mark a message as read.
+- **POST** `/messages/:id/replies`: Reply to a message.
+
+### WhatsApp Settings
+- **GET** `/whatsapp/settings`: Read organization WhatsApp settings.
+- **PUT** `/whatsapp/settings`: Update provider settings (`apiKey: ""` clears stored key).
+- **POST** `/whatsapp/settings/test-connection`: Test provider connection.
+- **GET** `/whatsapp/settings/groups`: Fetch provider groups.
+- **GET** `/whatsapp/settings/bindings`: List feature bindings.
+- **PUT** `/whatsapp/settings/bindings/:feature`: Upsert feature binding.
 
 ### Bookings
 - **POST** `/bookings`: Create a booking.

--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ src/
 - **POST** `/bookings`: Create a booking.
 - **GET** `/bookings/user/:userId`: List bookings for a user.
 - **GET** `/bookings`: List all bookings.
+- **GET** `/bookeddates`: List all bookings (alias used by `/admin/reservas`).
 - **DELETE** `/bookings/:id`: Delete a booking.
 - **GET** `/bookings/availability/:resourceId`: Check availability.
 - **GET** `/bookings/reserved-times`: Get reserved times.

--- a/src/api/api.module.ts
+++ b/src/api/api.module.ts
@@ -20,6 +20,7 @@ import { WhatsappSettingsController } from './controllers/whatsapp-settings.cont
 import { WhatsappSettingsService } from './services/whatsapp-settings.service';
 import { MessageController } from './controllers/message.controller';
 import { MessageService } from './services/message.service';
+import { JwtAuthGuard } from '../shared/auth/guards/jwt-auth.guard';
 
 @Module({
   imports: [
@@ -49,6 +50,7 @@ import { MessageService } from './services/message.service';
     BookingService,
     OrganizationService,
     WhatsappSettingsService,
+    JwtAuthGuard,
   ],
   exports: [UserService, JwtModule],
 })

--- a/src/api/api.module.ts
+++ b/src/api/api.module.ts
@@ -18,6 +18,8 @@ import { OrganizationService } from './services/organization.service';
 import { OrganizationController } from './controllers/organization.controller';
 import { WhatsappSettingsController } from './controllers/whatsapp-settings.controller';
 import { WhatsappSettingsService } from './services/whatsapp-settings.service';
+import { MessageController } from './controllers/message.controller';
+import { MessageService } from './services/message.service';
 
 @Module({
   imports: [
@@ -33,11 +35,21 @@ import { WhatsappSettingsService } from './services/whatsapp-settings.service';
     UserController,
     ResourceController,
     NoticeController,
+    MessageController,
     BookingController,
     OrganizationController,
     WhatsappSettingsController,
   ],
-  providers: [UserService, AuthService, ResourceService, NoticeService, BookingService, OrganizationService, WhatsappSettingsService],
+  providers: [
+    UserService,
+    AuthService,
+    ResourceService,
+    NoticeService,
+    MessageService,
+    BookingService,
+    OrganizationService,
+    WhatsappSettingsService,
+  ],
   exports: [UserService, JwtModule],
 })
 export class UserModule {}

--- a/src/api/api.module.ts
+++ b/src/api/api.module.ts
@@ -16,6 +16,8 @@ import { BookingService } from './services/booking.service';
 import { resolveJwtSecret } from '../shared/auth/jwt-secret.policy';
 import { OrganizationService } from './services/organization.service';
 import { OrganizationController } from './controllers/organization.controller';
+import { WhatsappSettingsController } from './controllers/whatsapp-settings.controller';
+import { WhatsappSettingsService } from './services/whatsapp-settings.service';
 
 @Module({
   imports: [
@@ -27,8 +29,15 @@ import { OrganizationController } from './controllers/organization.controller';
       signOptions: { expiresIn: '60m' },
     }),
   ],
-  controllers: [UserController, ResourceController, NoticeController, BookingController, OrganizationController],
-  providers: [UserService, AuthService, ResourceService, NoticeService, BookingService, OrganizationService],
+  controllers: [
+    UserController,
+    ResourceController,
+    NoticeController,
+    BookingController,
+    OrganizationController,
+    WhatsappSettingsController,
+  ],
+  providers: [UserService, AuthService, ResourceService, NoticeService, BookingService, OrganizationService, WhatsappSettingsService],
   exports: [UserService, JwtModule],
 })
 export class UserModule {}

--- a/src/api/controllers/booking.controller.spec.ts
+++ b/src/api/controllers/booking.controller.spec.ts
@@ -48,4 +48,34 @@ describe('BFF BookingController', () => {
       ),
     ).rejects.toBeInstanceOf(UnauthorizedException);
   });
+
+  it('forwards getAllBookings query with token', async () => {
+    const payload = { data: [], total: 0, page: 1, lastPage: 1 };
+    bookingService.getAllBookings.mockResolvedValue(payload);
+
+    await expect(
+      controller.getAllBookings(
+        { user: { token: 'jwt-token' } },
+        { page: 2, limit: 10, sort: 'startTime', order: 'ASC' },
+        undefined,
+        undefined,
+      ),
+    ).resolves.toEqual(payload);
+
+    expect(bookingService.getAllBookings).toHaveBeenCalledWith(
+      { page: 2, limit: 10, sort: 'startTime', order: 'ASC', startDate: undefined, endDate: undefined },
+      'jwt-token',
+    );
+  });
+
+  it('throws UnauthorizedException when getAllBookings token is missing', async () => {
+    await expect(
+      controller.getAllBookings(
+        { user: {} },
+        { page: 1, limit: 10 },
+        undefined,
+        undefined,
+      ),
+    ).rejects.toBeInstanceOf(UnauthorizedException);
+  });
 });

--- a/src/api/controllers/booking.controller.ts
+++ b/src/api/controllers/booking.controller.ts
@@ -2,7 +2,7 @@ import { Controller, Post, Get, Delete, Body, Param, Query, Req, UseGuards, Logg
 import { BookingService } from '../services/booking.service';
 import { JwtAuthGuard } from '../../shared/auth/guards/jwt-auth.guard';
 
-@Controller('bookings')
+@Controller(['bookings', 'bookeddates'])
 export class BookingController {
   private readonly logger = new Logger(BookingController.name);
 

--- a/src/api/controllers/message.controller.spec.ts
+++ b/src/api/controllers/message.controller.spec.ts
@@ -1,0 +1,73 @@
+import { ForbiddenException, UnauthorizedException } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { JwtAuthGuard } from '../../shared/auth/guards/jwt-auth.guard';
+import { UserRole } from '../entities/user.entity';
+import { MessageController } from './message.controller';
+import { MessageService } from '../services/message.service';
+
+describe('BFF MessageController', () => {
+  let controller: MessageController;
+  let service: jest.Mocked<MessageService>;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [MessageController],
+      providers: [
+        {
+          provide: MessageService,
+          useValue: {
+            createContactMessage: jest.fn(),
+            getAdminMessages: jest.fn(),
+            getUnreadCount: jest.fn(),
+            markAsRead: jest.fn(),
+            replyAsAdmin: jest.fn(),
+            deleteMessage: jest.fn(),
+            getContactEmailSettings: jest.fn(),
+            updateContactEmailSettings: jest.fn(),
+          },
+        },
+      ],
+    })
+      .overrideGuard(JwtAuthGuard)
+      .useValue({ canActivate: () => true })
+      .compile();
+
+    controller = module.get<MessageController>(MessageController);
+    service = module.get(MessageService) as jest.Mocked<MessageService>;
+  });
+
+  it('proxies contact email settings read for admin', async () => {
+    service.getContactEmailSettings.mockResolvedValue({ deliveryMode: 'in_app_only' } as any);
+
+    await expect(
+      controller.getContactEmailSettings({ user: { role: UserRole.ADMIN, token: 'jwt-token' } } as any),
+    ).resolves.toEqual({ deliveryMode: 'in_app_only' });
+
+    expect(service.getContactEmailSettings).toHaveBeenCalledWith('jwt-token');
+  });
+
+  it('rejects contact email settings read for non-admin users', async () => {
+    await expect(
+      controller.getContactEmailSettings({ user: { role: UserRole.RESIDENT, token: 'jwt-token' } } as any),
+    ).rejects.toThrow(ForbiddenException);
+  });
+
+  it('rejects contact email settings update without token', async () => {
+    await expect(
+      controller.updateContactEmailSettings(
+        { deliveryMode: 'in_app_only', replyToMode: 'resident_email' } as any,
+        { user: { role: UserRole.ADMIN } } as any,
+      ),
+    ).rejects.toThrow(UnauthorizedException);
+  });
+
+  it('proxies delete message for admin', async () => {
+    service.deleteMessage.mockResolvedValue({ success: true });
+
+    await expect(
+      controller.deleteMessage('message-1', { user: { role: UserRole.ADMIN, token: 'jwt-token' } } as any),
+    ).resolves.toEqual({ success: true });
+
+    expect(service.deleteMessage).toHaveBeenCalledWith('message-1', 'jwt-token');
+  });
+});

--- a/src/api/controllers/message.controller.spec.ts
+++ b/src/api/controllers/message.controller.spec.ts
@@ -52,6 +52,25 @@ describe('BFF MessageController', () => {
     ).rejects.toThrow(ForbiddenException);
   });
 
+  it('rejects admin inbox for non-admin users', async () => {
+    await expect(
+      controller.getAdminMessages(
+        { user: { role: UserRole.RESIDENT, token: 'jwt-token' } } as any,
+        {},
+      ),
+    ).rejects.toThrow(ForbiddenException);
+  });
+
+  it('rejects admin replies for non-admin users', async () => {
+    await expect(
+      controller.replyAsAdmin(
+        '11111111-1111-4111-8111-111111111111',
+        { content: 'reply' } as any,
+        { user: { role: UserRole.RESIDENT, token: 'jwt-token' } } as any,
+      ),
+    ).rejects.toThrow(ForbiddenException);
+  });
+
   it('rejects contact email settings update without token', async () => {
     await expect(
       controller.updateContactEmailSettings(

--- a/src/api/controllers/message.controller.ts
+++ b/src/api/controllers/message.controller.ts
@@ -54,12 +54,7 @@ export class MessageController {
   @Get('admin')
   async getAdminMessages(@Req() req: any, @Query() query: Record<string, unknown>): Promise<MessageListResponseDto> {
     this.logger.log('Received GET /messages/admin request');
-    const token = req.user?.token;
-
-    if (!token) {
-      this.logger.error('Authorization token is missing in the request');
-      throw new UnauthorizedException('Authorization token is missing');
-    }
+    const token = this.ensureAdminAndGetToken(req);
 
     return this.messageService.getAdminMessages(token, query);
   }
@@ -96,12 +91,7 @@ export class MessageController {
   @Post(':id/replies')
   async replyAsAdmin(@Param('id', new ParseUUIDPipe()) id: string, @Body(new JoiValidationPipe(CreateMessageReplySchema)) body: CreateMessageReplyDto, @Req() req: any) {
     this.logger.log(`Received POST /messages/${id}/replies request`);
-    const token = req.user?.token;
-
-    if (!token) {
-      this.logger.error('Authorization token is missing in the request');
-      throw new UnauthorizedException('Authorization token is missing');
-    }
+    const token = this.ensureAdminAndGetToken(req);
 
     return this.messageService.replyAsAdmin(id, body, token);
   }
@@ -142,8 +132,8 @@ export class MessageController {
     }
 
     if (req.user?.role !== UserRole.ADMIN) {
-      this.logger.error('User does not have admin permissions for contact email settings');
-      throw new ForbiddenException('You do not have permission to manage contact email settings');
+      this.logger.error('User does not have admin permissions to perform this action');
+      throw new ForbiddenException('You do not have permission to perform this action');
     }
 
     return token;

--- a/src/api/controllers/message.controller.ts
+++ b/src/api/controllers/message.controller.ts
@@ -6,6 +6,7 @@ import {
   Get,
   Logger,
   Param,
+  ParseUUIDPipe,
   Post,
   Put,
   Query,
@@ -79,7 +80,7 @@ export class MessageController {
 
   @UseGuards(JwtAuthGuard)
   @Post(':id/mark-read')
-  async markAsRead(@Param('id') id: string, @Req() req: any) {
+  async markAsRead(@Param('id', new ParseUUIDPipe()) id: string, @Req() req: any) {
     this.logger.log(`Received POST /messages/${id}/mark-read request`);
     const token = req.user?.token;
 
@@ -93,7 +94,7 @@ export class MessageController {
 
   @UseGuards(JwtAuthGuard)
   @Post(':id/replies')
-  async replyAsAdmin(@Param('id') id: string, @Body(new JoiValidationPipe(CreateMessageReplySchema)) body: CreateMessageReplyDto, @Req() req: any) {
+  async replyAsAdmin(@Param('id', new ParseUUIDPipe()) id: string, @Body(new JoiValidationPipe(CreateMessageReplySchema)) body: CreateMessageReplyDto, @Req() req: any) {
     this.logger.log(`Received POST /messages/${id}/replies request`);
     const token = req.user?.token;
 
@@ -107,7 +108,7 @@ export class MessageController {
 
   @UseGuards(JwtAuthGuard)
   @Delete(':id')
-  async deleteMessage(@Param('id') id: string, @Req() req: any) {
+  async deleteMessage(@Param('id', new ParseUUIDPipe()) id: string, @Req() req: any) {
     this.logger.log(`Received DELETE /messages/${id} request`);
     const token = this.ensureAdminAndGetToken(req);
     return this.messageService.deleteMessage(id, token);

--- a/src/api/controllers/message.controller.ts
+++ b/src/api/controllers/message.controller.ts
@@ -14,13 +14,17 @@ import {
   UseGuards,
 } from '@nestjs/common';
 import { JwtAuthGuard } from '../../shared/auth/guards/jwt-auth.guard';
+import { JoiValidationPipe } from '../../shared/pipes/joi-validation.pipe';
 import {
   ContactEmailSettingsDto,
   CreateContactMessageDto,
+  CreateContactMessageSchema,
   CreateMessageReplyDto,
+  CreateMessageReplySchema,
   MessageListResponseDto,
   MessageUnreadStateDto,
   UpdateContactEmailSettingsDto,
+  UpdateContactEmailSettingsSchema,
 } from '../dto/message.dto';
 import { UserRole } from '../entities/user.entity';
 import { MessageService } from '../services/message.service';
@@ -33,7 +37,7 @@ export class MessageController {
 
   @UseGuards(JwtAuthGuard)
   @Post('contact')
-  async createContactMessage(@Body() body: CreateContactMessageDto, @Req() req: any) {
+  async createContactMessage(@Body(new JoiValidationPipe(CreateContactMessageSchema)) body: CreateContactMessageDto, @Req() req: any) {
     this.logger.log('Received POST /messages/contact request');
     const token = req.user?.token;
 
@@ -89,7 +93,7 @@ export class MessageController {
 
   @UseGuards(JwtAuthGuard)
   @Post(':id/replies')
-  async replyAsAdmin(@Param('id') id: string, @Body() body: CreateMessageReplyDto, @Req() req: any) {
+  async replyAsAdmin(@Param('id') id: string, @Body(new JoiValidationPipe(CreateMessageReplySchema)) body: CreateMessageReplyDto, @Req() req: any) {
     this.logger.log(`Received POST /messages/${id}/replies request`);
     const token = req.user?.token;
 
@@ -120,7 +124,7 @@ export class MessageController {
   @UseGuards(JwtAuthGuard)
   @Put('settings/contact-email')
   async updateContactEmailSettings(
-    @Body() body: UpdateContactEmailSettingsDto,
+    @Body(new JoiValidationPipe(UpdateContactEmailSettingsSchema)) body: UpdateContactEmailSettingsDto,
     @Req() req: any,
   ): Promise<ContactEmailSettingsDto> {
     this.logger.log('Received PUT /messages/settings/contact-email request');

--- a/src/api/controllers/message.controller.ts
+++ b/src/api/controllers/message.controller.ts
@@ -1,0 +1,146 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  ForbiddenException,
+  Get,
+  Logger,
+  Param,
+  Post,
+  Put,
+  Query,
+  Req,
+  UnauthorizedException,
+  UseGuards,
+} from '@nestjs/common';
+import { JwtAuthGuard } from '../../shared/auth/guards/jwt-auth.guard';
+import {
+  ContactEmailSettingsDto,
+  CreateContactMessageDto,
+  CreateMessageReplyDto,
+  MessageListResponseDto,
+  MessageUnreadStateDto,
+  UpdateContactEmailSettingsDto,
+} from '../dto/message.dto';
+import { UserRole } from '../entities/user.entity';
+import { MessageService } from '../services/message.service';
+
+@Controller('messages')
+export class MessageController {
+  private readonly logger = new Logger(MessageController.name);
+
+  constructor(private readonly messageService: MessageService) {}
+
+  @UseGuards(JwtAuthGuard)
+  @Post('contact')
+  async createContactMessage(@Body() body: CreateContactMessageDto, @Req() req: any) {
+    this.logger.log('Received POST /messages/contact request');
+    const token = req.user?.token;
+
+    if (!token) {
+      this.logger.error('Authorization token is missing in the request');
+      throw new UnauthorizedException('Authorization token is missing');
+    }
+
+    return this.messageService.createContactMessage(body, token);
+  }
+
+  @UseGuards(JwtAuthGuard)
+  @Get('admin')
+  async getAdminMessages(@Req() req: any, @Query() query: Record<string, unknown>): Promise<MessageListResponseDto> {
+    this.logger.log('Received GET /messages/admin request');
+    const token = req.user?.token;
+
+    if (!token) {
+      this.logger.error('Authorization token is missing in the request');
+      throw new UnauthorizedException('Authorization token is missing');
+    }
+
+    return this.messageService.getAdminMessages(token, query);
+  }
+
+  @UseGuards(JwtAuthGuard)
+  @Get('unread-count')
+  async getUnreadCount(@Req() req: any): Promise<MessageUnreadStateDto> {
+    this.logger.log('Received GET /messages/unread-count request');
+    const token = req.user?.token;
+
+    if (!token) {
+      this.logger.error('Authorization token is missing in the request');
+      throw new UnauthorizedException('Authorization token is missing');
+    }
+
+    return this.messageService.getUnreadCount(token);
+  }
+
+  @UseGuards(JwtAuthGuard)
+  @Post(':id/mark-read')
+  async markAsRead(@Param('id') id: string, @Req() req: any) {
+    this.logger.log(`Received POST /messages/${id}/mark-read request`);
+    const token = req.user?.token;
+
+    if (!token) {
+      this.logger.error('Authorization token is missing in the request');
+      throw new UnauthorizedException('Authorization token is missing');
+    }
+
+    return this.messageService.markAsRead(id, token);
+  }
+
+  @UseGuards(JwtAuthGuard)
+  @Post(':id/replies')
+  async replyAsAdmin(@Param('id') id: string, @Body() body: CreateMessageReplyDto, @Req() req: any) {
+    this.logger.log(`Received POST /messages/${id}/replies request`);
+    const token = req.user?.token;
+
+    if (!token) {
+      this.logger.error('Authorization token is missing in the request');
+      throw new UnauthorizedException('Authorization token is missing');
+    }
+
+    return this.messageService.replyAsAdmin(id, body, token);
+  }
+
+  @UseGuards(JwtAuthGuard)
+  @Delete(':id')
+  async deleteMessage(@Param('id') id: string, @Req() req: any) {
+    this.logger.log(`Received DELETE /messages/${id} request`);
+    const token = this.ensureAdminAndGetToken(req);
+    return this.messageService.deleteMessage(id, token);
+  }
+
+  @UseGuards(JwtAuthGuard)
+  @Get('settings/contact-email')
+  async getContactEmailSettings(@Req() req: any): Promise<ContactEmailSettingsDto> {
+    this.logger.log('Received GET /messages/settings/contact-email request');
+    const token = this.ensureAdminAndGetToken(req);
+    return this.messageService.getContactEmailSettings(token);
+  }
+
+  @UseGuards(JwtAuthGuard)
+  @Put('settings/contact-email')
+  async updateContactEmailSettings(
+    @Body() body: UpdateContactEmailSettingsDto,
+    @Req() req: any,
+  ): Promise<ContactEmailSettingsDto> {
+    this.logger.log('Received PUT /messages/settings/contact-email request');
+    const token = this.ensureAdminAndGetToken(req);
+    return this.messageService.updateContactEmailSettings(body, token);
+  }
+
+  private ensureAdminAndGetToken(req: any): string {
+    const token = req.user?.token;
+
+    if (!token) {
+      this.logger.error('Authorization token is missing in the request');
+      throw new UnauthorizedException('Authorization token is missing');
+    }
+
+    if (req.user?.role !== UserRole.ADMIN) {
+      this.logger.error('User does not have admin permissions for contact email settings');
+      throw new ForbiddenException('You do not have permission to manage contact email settings');
+    }
+
+    return token;
+  }
+}

--- a/src/api/controllers/notice.controller.ts
+++ b/src/api/controllers/notice.controller.ts
@@ -14,8 +14,7 @@ import {
 } from '@nestjs/common';
 import { NoticeService } from '../services/notice.service';
 import { JwtAuthGuard } from '../../shared/auth/guards/jwt-auth.guard';
-import { CreateNoticeDto } from '../dto/notice.dto';
-import { NoticeUnreadStateDto } from '../dto/notice.dto';
+import { CreateNoticeDto, NoticeUnreadStateDto } from '../dto/notice.dto';
 
 @Controller('notices')
 export class NoticeController {

--- a/src/api/controllers/notice.controller.ts
+++ b/src/api/controllers/notice.controller.ts
@@ -15,6 +15,7 @@ import {
 import { NoticeService } from '../services/notice.service';
 import { JwtAuthGuard } from '../../shared/auth/guards/jwt-auth.guard';
 import { CreateNoticeDto } from '../dto/notice.dto';
+import { NoticeUnreadStateDto } from '../dto/notice.dto';
 
 @Controller('notices')
 export class NoticeController {
@@ -54,7 +55,7 @@ export class NoticeController {
 
   @UseGuards(JwtAuthGuard)
   @Get('unread-count')
-  async getUnreadCount(@Req() req: any) {
+  async getUnreadCount(@Req() req: any): Promise<NoticeUnreadStateDto> {
     this.logger.log('Received GET /notices/unread-count request');
     const token = req.user?.token;
 

--- a/src/api/controllers/user.controller.spec.ts
+++ b/src/api/controllers/user.controller.spec.ts
@@ -3,6 +3,7 @@ import { UserController } from './user.controller';
 import { UserService } from '../services/user.service';
 import { setAuthCookie, setCsrfCookie } from '../../shared/auth/auth-cookie.util';
 import { JwtAuthGuard } from '../../shared/auth/guards/jwt-auth.guard';
+import { BadRequestException } from '@nestjs/common';
 
 jest.mock('../../shared/auth/auth-cookie.util', () => ({
   setAuthCookie: jest.fn(),
@@ -30,6 +31,9 @@ describe('UserController', () => {
             updateUser: jest.fn(),
             logout: jest.fn(),
             deleteUser: jest.fn(),
+            setOnboardingEmail: jest.fn(),
+            verifyOnboardingEmail: jest.fn(),
+            changeOnboardingPassword: jest.fn(),
           },
         },
       ],
@@ -64,5 +68,24 @@ describe('UserController', () => {
     expect(setAuthCookie).toHaveBeenCalledWith(res, 'jwt-token', expect.any(Number));
     expect(setCsrfCookie).toHaveBeenCalledWith(res, response.csrfToken);
     expect(service.login).toHaveBeenCalledWith(loginUserDto);
+  });
+
+  it('proxies onboarding email endpoint with authenticated token', async () => {
+    service.setOnboardingEmail.mockResolvedValue({ message: 'ok' } as any);
+    await expect(
+      controller.setOnboardingEmail(
+        { user: { token: 'jwt-token' } } as any,
+        { email: 'resident@example.com' },
+      ),
+    ).resolves.toEqual({ message: 'ok' });
+  });
+
+  it('rejects password change through generic profile update', async () => {
+    await expect(
+      controller.updateProfile(
+        { user: { token: 'jwt-token' } } as any,
+        { password: 'Newpass123' } as any,
+      ),
+    ).rejects.toThrow(BadRequestException);
   });
 });

--- a/src/api/controllers/user.controller.spec.ts
+++ b/src/api/controllers/user.controller.spec.ts
@@ -27,6 +27,7 @@ describe('UserController', () => {
             getProfile: jest.fn(),
             getAllUsers: jest.fn(),
             updateProfile: jest.fn(),
+            updateUser: jest.fn(),
             logout: jest.fn(),
             deleteUser: jest.fn(),
           },

--- a/src/api/controllers/user.controller.ts
+++ b/src/api/controllers/user.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Post, Body, Logger, Get, Put, Delete, Param, Req, UseGuards, UnauthorizedException, Res } from '@nestjs/common';
+import { BadRequestException, Controller, Post, Body, Logger, Get, Put, Delete, Param, Req, UseGuards, UnauthorizedException, Res } from '@nestjs/common';
 import { CreateUserDto, CreateUserSchema } from '../dto/create-user.dto';
 import { LoginUserDto, LoginUserSchema } from '../dto/login-user.dto';
 import { UpdateUserDto, UpdateUserSchema } from '../dto/update-user.dto';
@@ -9,6 +9,14 @@ import { UserRole } from '../entities/user.entity';
 import { clearAuthCookie, clearCsrfCookie, setAuthCookie, setCsrfCookie } from '../../shared/auth/auth-cookie.util';
 import { Response } from 'express';
 import { randomBytes } from 'crypto';
+import {
+  ChangeOnboardingPasswordDto,
+  ChangeOnboardingPasswordSchema,
+  SetOnboardingEmailDto,
+  SetOnboardingEmailSchema,
+  VerifyOnboardingEmailDto,
+  VerifyOnboardingEmailSchema,
+} from '../dto/onboarding.dto';
 
 @Controller('users')
 export class UserController {
@@ -82,6 +90,9 @@ export class UserController {
       this.logger.error('Authorization token is missing in the request');
       throw new UnauthorizedException('Authorization token is missing');
     }
+    if (updateData.password !== undefined) {
+      throw new BadRequestException('Use onboarding password endpoint to change password');
+    }
 
     this.logger.log('Calling UserService to update user profile');
     return this.userService.updateProfile(updateData, token);
@@ -148,5 +159,44 @@ export class UserController {
 
     this.logger.log(`Calling UserService to delete user with ID: ${userId}`);
     return this.userService.deleteUser(userId, token);
+  }
+
+  @UseGuards(JwtAuthGuard)
+  @Post('onboarding/email')
+  async setOnboardingEmail(
+    @Req() req: any,
+    @Body(new JoiValidationPipe(SetOnboardingEmailSchema)) body: SetOnboardingEmailDto,
+  ) {
+    const token = req.user?.token;
+    if (!token) {
+      throw new UnauthorizedException('Authorization token is missing');
+    }
+    return this.userService.setOnboardingEmail(body, token);
+  }
+
+  @UseGuards(JwtAuthGuard)
+  @Post('onboarding/verify')
+  async verifyOnboardingEmail(
+    @Req() req: any,
+    @Body(new JoiValidationPipe(VerifyOnboardingEmailSchema)) body: VerifyOnboardingEmailDto,
+  ) {
+    const token = req.user?.token;
+    if (!token) {
+      throw new UnauthorizedException('Authorization token is missing');
+    }
+    return this.userService.verifyOnboardingEmail(body, token);
+  }
+
+  @UseGuards(JwtAuthGuard)
+  @Post('onboarding/change-password')
+  async changeOnboardingPassword(
+    @Req() req: any,
+    @Body(new JoiValidationPipe(ChangeOnboardingPasswordSchema)) body: ChangeOnboardingPasswordDto,
+  ) {
+    const token = req.user?.token;
+    if (!token) {
+      throw new UnauthorizedException('Authorization token is missing');
+    }
+    return this.userService.changeOnboardingPassword(body, token);
   }
 }

--- a/src/api/controllers/user.controller.ts
+++ b/src/api/controllers/user.controller.ts
@@ -10,6 +10,14 @@ import { clearAuthCookie, clearCsrfCookie, setAuthCookie, setCsrfCookie } from '
 import { Response } from 'express';
 import { randomBytes } from 'crypto';
 import {
+  ForgotPasswordConfirmDto,
+  ForgotPasswordConfirmSchema,
+  ForgotPasswordRequestDto,
+  ForgotPasswordRequestSchema,
+} from '../dto/forgot-password.dto';
+import {
+  ChangePasswordDto,
+  ChangePasswordSchema,
   ChangeOnboardingPasswordDto,
   ChangeOnboardingPasswordSchema,
   SetOnboardingEmailDto,
@@ -46,6 +54,20 @@ export class UserController {
       ...result,
       csrfToken,
     };
+  }
+
+  @Post('forgot-password/request')
+  async requestForgotPassword(
+    @Body(new JoiValidationPipe(ForgotPasswordRequestSchema)) body: ForgotPasswordRequestDto,
+  ) {
+    return this.userService.requestForgotPassword(body);
+  }
+
+  @Post('forgot-password/confirm')
+  async confirmForgotPassword(
+    @Body(new JoiValidationPipe(ForgotPasswordConfirmSchema)) body: ForgotPasswordConfirmDto,
+  ) {
+    return this.userService.confirmForgotPassword(body);
   }
 
   @UseGuards(JwtAuthGuard)
@@ -198,5 +220,18 @@ export class UserController {
       throw new UnauthorizedException('Authorization token is missing');
     }
     return this.userService.changeOnboardingPassword(body, token);
+  }
+
+  @UseGuards(JwtAuthGuard)
+  @Put('change-password')
+  async changePassword(
+    @Req() req: any,
+    @Body(new JoiValidationPipe(ChangePasswordSchema)) body: ChangePasswordDto,
+  ) {
+    const token = req.user?.token;
+    if (!token) {
+      throw new UnauthorizedException('Authorization token is missing');
+    }
+    return this.userService.changePassword(body, token);
   }
 }

--- a/src/api/controllers/user.controller.ts
+++ b/src/api/controllers/user.controller.ts
@@ -88,6 +88,28 @@ export class UserController {
   }
 
   @UseGuards(JwtAuthGuard)
+  @Put(':id')
+  async updateUser(@Req() req: any, @Param('id') userId: string, @Body(new JoiValidationPipe(UpdateUserSchema)) updateData: UpdateUserDto) {
+    this.logger.log('Entering UserController.updateUser');
+
+    const token = req.user?.token;
+    const userRole = req.user?.role;
+
+    if (!token) {
+      this.logger.error('Authorization token is missing in the request');
+      throw new UnauthorizedException('Authorization token is missing');
+    }
+
+    if (userRole !== UserRole.ADMIN) {
+      this.logger.error('Only admins can update users');
+      throw new UnauthorizedException('You do not have permission to update users');
+    }
+
+    this.logger.log(`Calling UserService to update user with ID: ${userId}`);
+    return this.userService.updateUser(userId, updateData, token);
+  }
+
+  @UseGuards(JwtAuthGuard)
   @Post('logout')
   async logout(@Req() req: any, @Res({ passthrough: true }) res: Response) {
     this.logger.log('Entering UserController.logout');

--- a/src/api/controllers/user.controller.ts
+++ b/src/api/controllers/user.controller.ts
@@ -1,4 +1,4 @@
-import { BadRequestException, Controller, Post, Body, Logger, Get, Put, Delete, Param, Req, UseGuards, UnauthorizedException, Res } from '@nestjs/common';
+import { BadRequestException, Controller, Post, Body, Logger, Get, Put, Delete, Param, Req, UseGuards, UnauthorizedException, Res, ForbiddenException } from '@nestjs/common';
 import { CreateUserDto, CreateUserSchema } from '../dto/create-user.dto';
 import { LoginUserDto, LoginUserSchema } from '../dto/login-user.dto';
 import { UpdateUserDto, UpdateUserSchema } from '../dto/update-user.dto';
@@ -121,7 +121,7 @@ export class UserController {
   }
 
   @UseGuards(JwtAuthGuard)
-  @Put(':id')
+  @Put(':id([0-9a-fA-F-]{36})')
   async updateUser(@Req() req: any, @Param('id') userId: string, @Body(new JoiValidationPipe(UpdateUserSchema)) updateData: UpdateUserDto) {
     this.logger.log('Entering UserController.updateUser');
 
@@ -135,7 +135,7 @@ export class UserController {
 
     if (userRole !== UserRole.ADMIN) {
       this.logger.error('Only admins can update users');
-      throw new UnauthorizedException('You do not have permission to update users');
+      throw new ForbiddenException('You do not have permission to update users');
     }
 
     this.logger.log(`Calling UserService to update user with ID: ${userId}`);

--- a/src/api/controllers/whatsapp-settings.controller.ts
+++ b/src/api/controllers/whatsapp-settings.controller.ts
@@ -1,16 +1,34 @@
-import { Body, Controller, ForbiddenException, Get, Logger, Param, Post, Put, Req, UnauthorizedException, UseGuards } from '@nestjs/common';
+import {
+  BadRequestException,
+  Body,
+  Controller,
+  ForbiddenException,
+  Get,
+  Logger,
+  Param,
+  Post,
+  Put,
+  Req,
+  UnauthorizedException,
+  UseGuards,
+} from '@nestjs/common';
 import { JwtAuthGuard } from '../../shared/auth/guards/jwt-auth.guard';
+import { JoiValidationPipe } from '../../shared/pipes/joi-validation.pipe';
 import { UserRole } from '../entities/user.entity';
 import { WhatsappSettingsService } from '../services/whatsapp-settings.service';
 import {
+  TestWhatsappConnectionSchema,
   TestWhatsappConnectionDto,
+  UpdateWhatsappSettingsSchema,
   UpdateWhatsappSettingsDto,
+  UpsertWhatsappGroupBindingSchema,
   UpsertWhatsappGroupBindingDto,
 } from '../dto/whatsapp-settings.dto';
 
 @Controller('whatsapp/settings')
 export class WhatsappSettingsController {
   private readonly logger = new Logger(WhatsappSettingsController.name);
+  private static readonly FEATURE_PARAM_PATTERN = /^[A-Za-z0-9-]+$/;
 
   constructor(private readonly whatsappSettingsService: WhatsappSettingsService) {}
 
@@ -32,7 +50,10 @@ export class WhatsappSettingsController {
 
   @UseGuards(JwtAuthGuard)
   @Put()
-  async updateSettings(@Body() body: UpdateWhatsappSettingsDto, @Req() req: any) {
+  async updateSettings(
+    @Body(new JoiValidationPipe(UpdateWhatsappSettingsSchema)) body: UpdateWhatsappSettingsDto,
+    @Req() req: any,
+  ) {
     this.logger.log('Received PUT /whatsapp/settings request');
     const token = this.ensureAdminAndGetToken(req);
     return this.whatsappSettingsService.updateSettings(body, token);
@@ -40,7 +61,10 @@ export class WhatsappSettingsController {
 
   @UseGuards(JwtAuthGuard)
   @Post('test-connection')
-  async testConnection(@Body() body: TestWhatsappConnectionDto, @Req() req: any) {
+  async testConnection(
+    @Body(new JoiValidationPipe(TestWhatsappConnectionSchema)) body: TestWhatsappConnectionDto,
+    @Req() req: any,
+  ) {
     this.logger.log('Received POST /whatsapp/settings/test-connection request');
     const token = this.ensureAdminAndGetToken(req);
     return this.whatsappSettingsService.testConnection(body, token);
@@ -64,10 +88,20 @@ export class WhatsappSettingsController {
 
   @UseGuards(JwtAuthGuard)
   @Put('bindings/:feature')
-  async upsertBinding(@Param('feature') feature: string, @Body() body: UpsertWhatsappGroupBindingDto, @Req() req: any) {
+  async upsertBinding(
+    @Param('feature') feature: string,
+    @Body(new JoiValidationPipe(UpsertWhatsappGroupBindingSchema)) body: UpsertWhatsappGroupBindingDto,
+    @Req() req: any,
+  ) {
+    const normalizedFeature = feature.trim().toLowerCase();
+    if (!WhatsappSettingsController.FEATURE_PARAM_PATTERN.test(normalizedFeature)) {
+      this.logger.warn(`Received invalid feature parameter in PUT /whatsapp/settings/bindings/${feature} request`);
+      throw new BadRequestException('Invalid feature parameter');
+    }
+
     this.logger.log(`Received PUT /whatsapp/settings/bindings/${feature} request`);
     const token = this.ensureAdminAndGetToken(req);
-    return this.whatsappSettingsService.upsertBinding(feature, body, token);
+    return this.whatsappSettingsService.upsertBinding(normalizedFeature, body, token);
   }
 
   private ensureAdminAndGetToken(req: any): string {

--- a/src/api/controllers/whatsapp-settings.controller.ts
+++ b/src/api/controllers/whatsapp-settings.controller.ts
@@ -95,11 +95,11 @@ export class WhatsappSettingsController {
   ) {
     const normalizedFeature = feature.trim().toLowerCase();
     if (!WhatsappSettingsController.FEATURE_PARAM_PATTERN.test(normalizedFeature)) {
-      this.logger.warn(`Received invalid feature parameter in PUT /whatsapp/settings/bindings/${feature} request`);
+      this.logger.warn('Received invalid feature parameter in PUT /whatsapp/settings/bindings request');
       throw new BadRequestException('Invalid feature parameter');
     }
 
-    this.logger.log(`Received PUT /whatsapp/settings/bindings/${feature} request`);
+    this.logger.log(`Received PUT /whatsapp/settings/bindings/${normalizedFeature} request`);
     const token = this.ensureAdminAndGetToken(req);
     return this.whatsappSettingsService.upsertBinding(normalizedFeature, body, token);
   }

--- a/src/api/controllers/whatsapp-settings.controller.ts
+++ b/src/api/controllers/whatsapp-settings.controller.ts
@@ -1,0 +1,87 @@
+import { Body, Controller, ForbiddenException, Get, Logger, Param, Post, Put, Req, UnauthorizedException, UseGuards } from '@nestjs/common';
+import { JwtAuthGuard } from '../../shared/auth/guards/jwt-auth.guard';
+import { UserRole } from '../entities/user.entity';
+import { WhatsappSettingsService } from '../services/whatsapp-settings.service';
+import {
+  TestWhatsappConnectionDto,
+  UpdateWhatsappSettingsDto,
+  UpsertWhatsappGroupBindingDto,
+} from '../dto/whatsapp-settings.dto';
+
+@Controller('whatsapp/settings')
+export class WhatsappSettingsController {
+  private readonly logger = new Logger(WhatsappSettingsController.name);
+
+  constructor(private readonly whatsappSettingsService: WhatsappSettingsService) {}
+
+  @UseGuards(JwtAuthGuard)
+  @Get()
+  async getSettings(@Req() req: any) {
+    this.logger.log('Received GET /whatsapp/settings request');
+    const token = this.ensureAdminAndGetToken(req);
+    return this.whatsappSettingsService.getSettings(token);
+  }
+
+  @UseGuards(JwtAuthGuard)
+  @Post('bootstrap-legacy')
+  async bootstrapLegacy(@Req() req: any) {
+    this.logger.log('Received POST /whatsapp/settings/bootstrap-legacy request');
+    const token = this.ensureAdminAndGetToken(req);
+    return this.whatsappSettingsService.bootstrapLegacy(token);
+  }
+
+  @UseGuards(JwtAuthGuard)
+  @Put()
+  async updateSettings(@Body() body: UpdateWhatsappSettingsDto, @Req() req: any) {
+    this.logger.log('Received PUT /whatsapp/settings request');
+    const token = this.ensureAdminAndGetToken(req);
+    return this.whatsappSettingsService.updateSettings(body, token);
+  }
+
+  @UseGuards(JwtAuthGuard)
+  @Post('test-connection')
+  async testConnection(@Body() body: TestWhatsappConnectionDto, @Req() req: any) {
+    this.logger.log('Received POST /whatsapp/settings/test-connection request');
+    const token = this.ensureAdminAndGetToken(req);
+    return this.whatsappSettingsService.testConnection(body, token);
+  }
+
+  @UseGuards(JwtAuthGuard)
+  @Get('groups')
+  async getGroups(@Req() req: any) {
+    this.logger.log('Received GET /whatsapp/settings/groups request');
+    const token = this.ensureAdminAndGetToken(req);
+    return this.whatsappSettingsService.getGroups(token);
+  }
+
+  @UseGuards(JwtAuthGuard)
+  @Get('bindings')
+  async getBindings(@Req() req: any) {
+    this.logger.log('Received GET /whatsapp/settings/bindings request');
+    const token = this.ensureAdminAndGetToken(req);
+    return this.whatsappSettingsService.getBindings(token);
+  }
+
+  @UseGuards(JwtAuthGuard)
+  @Put('bindings/:feature')
+  async upsertBinding(@Param('feature') feature: string, @Body() body: UpsertWhatsappGroupBindingDto, @Req() req: any) {
+    this.logger.log(`Received PUT /whatsapp/settings/bindings/${feature} request`);
+    const token = this.ensureAdminAndGetToken(req);
+    return this.whatsappSettingsService.upsertBinding(feature, body, token);
+  }
+
+  private ensureAdminAndGetToken(req: any): string {
+    const token = req.user?.token;
+    if (!token) {
+      this.logger.error('Authorization token is missing in the request');
+      throw new UnauthorizedException('Authorization token is missing');
+    }
+
+    if (req.user?.role !== UserRole.ADMIN) {
+      this.logger.error('User does not have admin permissions for WhatsApp settings');
+      throw new ForbiddenException('You do not have permission to manage WhatsApp settings');
+    }
+
+    return token;
+  }
+}

--- a/src/api/dto/create-user.dto.ts
+++ b/src/api/dto/create-user.dto.ts
@@ -1,8 +1,7 @@
 import * as Joi from '@hapi/joi';
 import { UserRole } from '../entities/user.entity';
 import { normalizeSlug } from '../../shared/slug/normalize-slug.util';
-
-const PASSWORD_POLICY_REGEX = /^(?=.*[A-Z])(?=.*\d)(?=.*[^A-Za-z0-9])(?=\S+$).{8,100}$/;
+import { PASSWORD_POLICY_MESSAGE, PASSWORD_POLICY_REGEX } from '../../shared/validation/password-policy';
 
 export class CreateUserDto {
   organizationSlug!: string;
@@ -31,7 +30,7 @@ export const CreateUserSchema = Joi.object({
     .pattern(PASSWORD_POLICY_REGEX)
     .required()
     .messages({
-      'string.pattern.base': 'Password must have at least 8 chars, one uppercase letter, one number, and one special character',
+      'string.pattern.base': PASSWORD_POLICY_MESSAGE,
     }),
   apartment: Joi.string().required(),
   block: Joi.number().valid(1, 2).required(),

--- a/src/api/dto/create-user.dto.ts
+++ b/src/api/dto/create-user.dto.ts
@@ -5,7 +5,7 @@ import { normalizeSlug } from '../../shared/slug/normalize-slug.util';
 export class CreateUserDto {
   organizationSlug!: string;
   name!: string;
-  email!: string;
+  email?: string | null;
   password!: string;
   apartment!: string;
   block!: number;
@@ -24,7 +24,7 @@ export const CreateUserSchema = Joi.object({
     }, 'organization slug normalization')
     .messages({ 'any.invalid': 'organizationSlug must contain at least one alphanumeric character' }),
   name: Joi.string().required(),
-  email: Joi.string().email().required(),
+  email: Joi.string().trim().email().allow('', null).optional(),
   password: Joi.string().min(8).required(),
   apartment: Joi.string().required(),
   block: Joi.number().valid(1, 2).required(),

--- a/src/api/dto/create-user.dto.ts
+++ b/src/api/dto/create-user.dto.ts
@@ -2,6 +2,8 @@ import * as Joi from '@hapi/joi';
 import { UserRole } from '../entities/user.entity';
 import { normalizeSlug } from '../../shared/slug/normalize-slug.util';
 
+const PASSWORD_POLICY_REGEX = /^(?=.*[A-Z])(?=.*\d)(?=.*[^A-Za-z0-9])(?=\S+$).{8,100}$/;
+
 export class CreateUserDto {
   organizationSlug!: string;
   name!: string;
@@ -25,7 +27,12 @@ export const CreateUserSchema = Joi.object({
     .messages({ 'any.invalid': 'organizationSlug must contain at least one alphanumeric character' }),
   name: Joi.string().required(),
   email: Joi.string().trim().email().allow('', null).optional(),
-  password: Joi.string().min(8).required(),
+  password: Joi.string()
+    .pattern(PASSWORD_POLICY_REGEX)
+    .required()
+    .messages({
+      'string.pattern.base': 'Password must have at least 8 chars, one uppercase letter, one number, and one special character',
+    }),
   apartment: Joi.string().required(),
   block: Joi.number().valid(1, 2).required(),
   role: Joi.string().valid(UserRole.ADMIN, UserRole.RESIDENT).default(UserRole.RESIDENT),

--- a/src/api/dto/forgot-password.dto.ts
+++ b/src/api/dto/forgot-password.dto.ts
@@ -1,0 +1,30 @@
+import * as Joi from '@hapi/joi';
+
+const PASSWORD_POLICY_REGEX = /^(?=.*[A-Z])(?=.*\d)(?=.*[^A-Za-z0-9])(?=\S+$).{8,100}$/;
+
+export class ForgotPasswordRequestDto {
+  organizationSlug!: string;
+  email!: string;
+}
+
+export const ForgotPasswordRequestSchema = Joi.object({
+  organizationSlug: Joi.string().trim().required(),
+  email: Joi.string().trim().email().max(100).required(),
+});
+
+export class ForgotPasswordConfirmDto {
+  organizationSlug!: string;
+  token!: string;
+  newPassword!: string;
+}
+
+export const ForgotPasswordConfirmSchema = Joi.object({
+  organizationSlug: Joi.string().trim().required(),
+  token: Joi.string().trim().min(20).max(512).required(),
+  newPassword: Joi.string()
+    .pattern(PASSWORD_POLICY_REGEX)
+    .required()
+    .messages({
+      'string.pattern.base': 'Password must have at least 8 chars, one uppercase letter, one number, and one special character',
+    }),
+});

--- a/src/api/dto/forgot-password.dto.ts
+++ b/src/api/dto/forgot-password.dto.ts
@@ -1,6 +1,5 @@
 import * as Joi from '@hapi/joi';
-
-const PASSWORD_POLICY_REGEX = /^(?=.*[A-Z])(?=.*\d)(?=.*[^A-Za-z0-9])(?=\S+$).{8,100}$/;
+import { PASSWORD_POLICY_MESSAGE, PASSWORD_POLICY_REGEX } from '../../shared/validation/password-policy';
 
 export class ForgotPasswordRequestDto {
   organizationSlug!: string;
@@ -25,6 +24,6 @@ export const ForgotPasswordConfirmSchema = Joi.object({
     .pattern(PASSWORD_POLICY_REGEX)
     .required()
     .messages({
-      'string.pattern.base': 'Password must have at least 8 chars, one uppercase letter, one number, and one special character',
+      'string.pattern.base': PASSWORD_POLICY_MESSAGE,
     }),
 });

--- a/src/api/dto/login-user.dto.ts
+++ b/src/api/dto/login-user.dto.ts
@@ -21,5 +21,5 @@ export const LoginUserSchema = Joi.object({
     .messages({ 'any.invalid': 'organizationSlug must contain at least one alphanumeric character' }),
   apartment: Joi.string().required(),
   block: Joi.number().valid(1, 2).required(),
-  password: Joi.string().min(8).max(12).required(),
+  password: Joi.string().min(1).max(100).required(),
 });

--- a/src/api/dto/message.dto.ts
+++ b/src/api/dto/message.dto.ts
@@ -71,6 +71,12 @@ export interface ContactEmailSettingsDto {
   fromEmail: string | null;
   replyToMode: ContactEmailReplyToMode;
   customReplyTo: string | null;
+  smtpHost: string | null;
+  smtpPort: number | null;
+  smtpSecure: boolean | null;
+  smtpUser: string | null;
+  smtpFrom: string | null;
+  hasSmtpPassword: boolean;
   canSendEmail: boolean;
   validationErrors: string[];
 }
@@ -82,4 +88,10 @@ export interface UpdateContactEmailSettingsDto {
   fromEmail?: string | null;
   replyToMode: ContactEmailReplyToMode;
   customReplyTo?: string | null;
+  smtpHost?: string | null;
+  smtpPort?: number | null;
+  smtpSecure?: boolean | null;
+  smtpUser?: string | null;
+  smtpFrom?: string | null;
+  smtpAppPassword?: string | null;
 }

--- a/src/api/dto/message.dto.ts
+++ b/src/api/dto/message.dto.ts
@@ -1,0 +1,85 @@
+export type ContactMessageCategory = 'suggestion' | 'complaint' | 'question';
+export type ContactMessageStatus = 'unread' | 'read' | 'replied';
+export type MessageEmailDeliveryStatus = 'not_requested' | 'pending' | 'sent' | 'failed' | 'skipped';
+export type ContactEmailDeliveryMode = 'in_app_only' | 'in_app_and_email';
+export type ContactEmailReplyToMode = 'resident_email' | 'custom';
+
+export interface CreateContactMessageDto {
+  subject: string;
+  category: ContactMessageCategory;
+  content: string;
+}
+
+export interface CreateMessageReplyDto {
+  content: string;
+  sendViaEmail?: boolean;
+}
+
+export interface MessageReplyDto {
+  id: string;
+  messageId: string;
+  authorUserId: string;
+  authorName: string;
+  content: string;
+  sendViaEmail: boolean;
+  emailDeliveryStatus: MessageEmailDeliveryStatus;
+  emailProviderMessageId?: string | null;
+  emailSentAt?: string | null;
+  emailLastError?: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface MessageDto {
+  id: string;
+  senderUserId: string;
+  senderName: string;
+  senderEmail: string;
+  senderApartment?: string | null;
+  senderBlock?: number | null;
+  subject: string;
+  category: ContactMessageCategory;
+  content: string;
+  status: ContactMessageStatus;
+  readAt?: string | null;
+  adminEmailDeliveryStatus: MessageEmailDeliveryStatus;
+  adminEmailProviderMessageId?: string | null;
+  adminEmailSentAt?: string | null;
+  adminEmailLastError?: string | null;
+  organizationId?: string;
+  replies?: MessageReplyDto[];
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface MessageListResponseDto {
+  data: MessageDto[];
+  total: number;
+  page: number;
+  lastPage: number;
+}
+
+export interface MessageUnreadStateDto {
+  unreadCount: number;
+  hasUnread: boolean;
+}
+
+export interface ContactEmailSettingsDto {
+  deliveryMode: ContactEmailDeliveryMode;
+  recipientEmails: string[];
+  fromName: string | null;
+  fromEmail: string | null;
+  replyToMode: ContactEmailReplyToMode;
+  customReplyTo: string | null;
+  canSendEmail: boolean;
+  validationErrors: string[];
+}
+
+export interface UpdateContactEmailSettingsDto {
+  deliveryMode: ContactEmailDeliveryMode;
+  recipientEmails?: string[];
+  fromName?: string | null;
+  fromEmail?: string | null;
+  replyToMode: ContactEmailReplyToMode;
+  customReplyTo?: string | null;
+}

--- a/src/api/dto/message.dto.ts
+++ b/src/api/dto/message.dto.ts
@@ -1,8 +1,36 @@
+import * as Joi from '@hapi/joi';
+
 export type ContactMessageCategory = 'suggestion' | 'complaint' | 'question';
 export type ContactMessageStatus = 'unread' | 'read' | 'replied';
 export type MessageEmailDeliveryStatus = 'not_requested' | 'pending' | 'sent' | 'failed' | 'skipped';
 export type ContactEmailDeliveryMode = 'in_app_only' | 'in_app_and_email';
 export type ContactEmailReplyToMode = 'resident_email' | 'custom';
+
+export const CreateContactMessageSchema = Joi.object({
+  subject: Joi.string().trim().max(255).required(),
+  category: Joi.string().valid('suggestion', 'complaint', 'question').required(),
+  content: Joi.string().trim().max(10000).required(),
+});
+
+export const CreateMessageReplySchema = Joi.object({
+  content: Joi.string().trim().max(10000).required(),
+  sendViaEmail: Joi.boolean().optional(),
+});
+
+export const UpdateContactEmailSettingsSchema = Joi.object({
+  deliveryMode: Joi.string().valid('in_app_only', 'in_app_and_email').required(),
+  recipientEmails: Joi.array().items(Joi.string().trim().email()).optional(),
+  fromName: Joi.string().trim().max(120).allow('', null).optional(),
+  fromEmail: Joi.string().trim().email().max(150).allow('', null).optional(),
+  replyToMode: Joi.string().valid('resident_email', 'custom').required(),
+  customReplyTo: Joi.string().trim().email().max(150).allow('', null).optional(),
+  smtpHost: Joi.string().trim().max(255).allow('', null).optional(),
+  smtpPort: Joi.number().integer().min(1).max(65535).allow(null).optional(),
+  smtpSecure: Joi.boolean().allow(null).optional(),
+  smtpUser: Joi.string().trim().max(255).allow('', null).optional(),
+  smtpFrom: Joi.string().trim().email().max(150).allow('', null).optional(),
+  smtpAppPassword: Joi.string().trim().max(500).allow('', null).optional(),
+});
 
 export interface CreateContactMessageDto {
   subject: string;

--- a/src/api/dto/notice.dto.ts
+++ b/src/api/dto/notice.dto.ts
@@ -29,3 +29,8 @@ export interface NoticeDto {
   createdAt: string;
   updatedAt: string;
 }
+
+export interface NoticeUnreadStateDto {
+  hasUnread: boolean;
+  lastSeenNoticesAt: string | null;
+}

--- a/src/api/dto/notice.dto.ts
+++ b/src/api/dto/notice.dto.ts
@@ -31,6 +31,7 @@ export interface NoticeDto {
 }
 
 export interface NoticeUnreadStateDto {
+  unreadCount: number;
   hasUnread: boolean;
   lastSeenNoticesAt: string | null;
 }

--- a/src/api/dto/onboarding.dto.ts
+++ b/src/api/dto/onboarding.dto.ts
@@ -1,6 +1,5 @@
 import * as Joi from '@hapi/joi';
-
-const PASSWORD_POLICY_REGEX = /^(?=.*[A-Z])(?=.*\d)(?=.*[^A-Za-z0-9])(?=\S+$).{8,100}$/;
+import { PASSWORD_POLICY_MESSAGE, PASSWORD_POLICY_REGEX } from '../../shared/validation/password-policy';
 
 export class SetOnboardingEmailDto {
   email!: string;
@@ -29,7 +28,7 @@ export const ChangeOnboardingPasswordSchema = Joi.object({
     .pattern(PASSWORD_POLICY_REGEX)
     .required()
     .messages({
-      'string.pattern.base': 'Password must have at least 8 chars, one uppercase letter, one number, and one special character',
+      'string.pattern.base': PASSWORD_POLICY_MESSAGE,
     }),
 });
 
@@ -44,7 +43,7 @@ export const ChangePasswordSchema = Joi.object({
     .pattern(PASSWORD_POLICY_REGEX)
     .required()
     .messages({
-      'string.pattern.base': 'Password must have at least 8 chars, one uppercase letter, one number, and one special character',
+      'string.pattern.base': PASSWORD_POLICY_MESSAGE,
     }),
 });
 

--- a/src/api/dto/onboarding.dto.ts
+++ b/src/api/dto/onboarding.dto.ts
@@ -1,0 +1,34 @@
+import * as Joi from '@hapi/joi';
+
+export class SetOnboardingEmailDto {
+  email!: string;
+}
+
+export const SetOnboardingEmailSchema = Joi.object({
+  email: Joi.string().trim().email().max(100).required(),
+});
+
+export class VerifyOnboardingEmailDto {
+  token!: string;
+}
+
+export const VerifyOnboardingEmailSchema = Joi.object({
+  token: Joi.string().trim().min(20).max(512).required(),
+});
+
+export class ChangeOnboardingPasswordDto {
+  currentPassword!: string;
+  newPassword!: string;
+}
+
+export const ChangeOnboardingPasswordSchema = Joi.object({
+  currentPassword: Joi.string().min(8).max(100).required(),
+  newPassword: Joi.string().min(8).max(100).required(),
+});
+
+export interface OnboardingFlagsDto {
+  mustProvideEmail: boolean;
+  mustVerifyEmail: boolean;
+  mustChangePassword: boolean;
+  onboardingRequired: boolean;
+}

--- a/src/api/dto/onboarding.dto.ts
+++ b/src/api/dto/onboarding.dto.ts
@@ -1,5 +1,7 @@
 import * as Joi from '@hapi/joi';
 
+const PASSWORD_POLICY_REGEX = /^(?=.*[A-Z])(?=.*\d)(?=.*[^A-Za-z0-9])(?=\S+$).{8,100}$/;
+
 export class SetOnboardingEmailDto {
   email!: string;
 }
@@ -22,8 +24,28 @@ export class ChangeOnboardingPasswordDto {
 }
 
 export const ChangeOnboardingPasswordSchema = Joi.object({
-  currentPassword: Joi.string().min(8).max(100).required(),
-  newPassword: Joi.string().min(8).max(100).required(),
+  currentPassword: Joi.string().min(1).max(100).required(),
+  newPassword: Joi.string()
+    .pattern(PASSWORD_POLICY_REGEX)
+    .required()
+    .messages({
+      'string.pattern.base': 'Password must have at least 8 chars, one uppercase letter, one number, and one special character',
+    }),
+});
+
+export class ChangePasswordDto {
+  currentPassword!: string;
+  newPassword!: string;
+}
+
+export const ChangePasswordSchema = Joi.object({
+  currentPassword: Joi.string().min(1).max(100).required(),
+  newPassword: Joi.string()
+    .pattern(PASSWORD_POLICY_REGEX)
+    .required()
+    .messages({
+      'string.pattern.base': 'Password must have at least 8 chars, one uppercase letter, one number, and one special character',
+    }),
 });
 
 export interface OnboardingFlagsDto {

--- a/src/api/dto/update-user.dto.ts
+++ b/src/api/dto/update-user.dto.ts
@@ -1,8 +1,15 @@
 import * as Joi from '@hapi/joi';
 
+const PASSWORD_POLICY_REGEX = /^(?=.*[A-Z])(?=.*\d)(?=.*[^A-Za-z0-9])(?=\S+$).{8,100}$/;
+
 export const UpdateUserSchema = Joi.object({
   name: Joi.string().optional(),
-  password: Joi.string().min(8).optional(),
+  password: Joi.string()
+    .pattern(PASSWORD_POLICY_REGEX)
+    .optional()
+    .messages({
+      'string.pattern.base': 'Password must have at least 8 chars, one uppercase letter, one number, and one special character',
+    }),
   email: Joi.string().trim().email().allow('', null).optional(),
   apartment: Joi.string().optional(),
   block: Joi.number().valid(1, 2).optional(),

--- a/src/api/dto/update-user.dto.ts
+++ b/src/api/dto/update-user.dto.ts
@@ -3,7 +3,7 @@ import * as Joi from '@hapi/joi';
 export const UpdateUserSchema = Joi.object({
   name: Joi.string().optional(),
   password: Joi.string().min(8).optional(),
-  email: Joi.string().email().optional(),
+  email: Joi.string().trim().email().allow('', null).optional(),
   apartment: Joi.string().optional(),
   block: Joi.number().valid(1, 2).optional(),
 });
@@ -11,7 +11,7 @@ export const UpdateUserSchema = Joi.object({
 export class UpdateUserDto {
   name?: string;
   password?: string;
-  email?: string;
+  email?: string | null;
   apartment?: string;
   block?: number;
 }

--- a/src/api/dto/update-user.dto.ts
+++ b/src/api/dto/update-user.dto.ts
@@ -1,6 +1,5 @@
 import * as Joi from '@hapi/joi';
-
-const PASSWORD_POLICY_REGEX = /^(?=.*[A-Z])(?=.*\d)(?=.*[^A-Za-z0-9])(?=\S+$).{8,100}$/;
+import { PASSWORD_POLICY_MESSAGE, PASSWORD_POLICY_REGEX } from '../../shared/validation/password-policy';
 
 export const UpdateUserSchema = Joi.object({
   name: Joi.string().optional(),
@@ -8,7 +7,7 @@ export const UpdateUserSchema = Joi.object({
     .pattern(PASSWORD_POLICY_REGEX)
     .optional()
     .messages({
-      'string.pattern.base': 'Password must have at least 8 chars, one uppercase letter, one number, and one special character',
+      'string.pattern.base': PASSWORD_POLICY_MESSAGE,
     }),
   email: Joi.string().trim().email().allow('', null).optional(),
   apartment: Joi.string().optional(),

--- a/src/api/dto/whatsapp-settings.dto.ts
+++ b/src/api/dto/whatsapp-settings.dto.ts
@@ -3,7 +3,7 @@ import * as Joi from '@hapi/joi';
 export const UpdateWhatsappSettingsSchema = Joi.object({
   baseUrl: Joi.string().trim().uri({ scheme: ['http', 'https'] }).required(),
   instanceName: Joi.string().trim().max(120).required(),
-  apiKey: Joi.string().trim().max(500).allow('').optional(),
+  apiKey: Joi.string().trim().max(500).allow('', null).optional(),
   whatsappNumber: Joi.string().trim().max(40).allow('', null).optional(),
   autoSendNotices: Joi.boolean().optional(),
 });
@@ -22,7 +22,7 @@ export const UpsertWhatsappGroupBindingSchema = Joi.object({
 export interface UpdateWhatsappSettingsDto {
   baseUrl: string;
   instanceName: string;
-  apiKey?: string;
+  apiKey?: string | null;
   whatsappNumber?: string | null;
   autoSendNotices?: boolean;
 }

--- a/src/api/dto/whatsapp-settings.dto.ts
+++ b/src/api/dto/whatsapp-settings.dto.ts
@@ -1,3 +1,24 @@
+import * as Joi from '@hapi/joi';
+
+export const UpdateWhatsappSettingsSchema = Joi.object({
+  baseUrl: Joi.string().trim().uri({ scheme: ['http', 'https'] }).required(),
+  instanceName: Joi.string().trim().max(120).required(),
+  apiKey: Joi.string().trim().max(500).allow('').optional(),
+  whatsappNumber: Joi.string().trim().max(40).allow('', null).optional(),
+  autoSendNotices: Joi.boolean().optional(),
+});
+
+export const TestWhatsappConnectionSchema = Joi.object({
+  baseUrl: Joi.string().trim().uri({ scheme: ['http', 'https'] }).optional(),
+  instanceName: Joi.string().trim().max(120).optional(),
+  apiKey: Joi.string().trim().max(500).optional(),
+});
+
+export const UpsertWhatsappGroupBindingSchema = Joi.object({
+  groupJid: Joi.string().trim().max(191).required(),
+  groupName: Joi.string().trim().max(180).allow('', null).optional(),
+});
+
 export interface UpdateWhatsappSettingsDto {
   baseUrl: string;
   instanceName: string;

--- a/src/api/dto/whatsapp-settings.dto.ts
+++ b/src/api/dto/whatsapp-settings.dto.ts
@@ -1,0 +1,42 @@
+export interface UpdateWhatsappSettingsDto {
+  baseUrl: string;
+  instanceName: string;
+  apiKey?: string;
+  whatsappNumber?: string | null;
+  autoSendNotices?: boolean;
+}
+
+export interface TestWhatsappConnectionDto {
+  baseUrl?: string;
+  instanceName?: string;
+  apiKey?: string;
+}
+
+export interface UpsertWhatsappGroupBindingDto {
+  groupJid: string;
+  groupName?: string | null;
+}
+
+export interface WhatsappGroupOptionDto {
+  groupJid: string;
+  groupName: string;
+}
+
+export interface WhatsappGroupBindingDto {
+  feature: string;
+  groupJid: string;
+  groupName: string | null;
+}
+
+export interface WhatsappSettingsViewDto {
+  provider: string;
+  status: 'connected' | 'disconnected';
+  baseUrl: string;
+  instanceName: string;
+  hasApiKey: boolean;
+  apiKeyMasked: string | null;
+  whatsappNumber: string | null;
+  autoSendNotices: boolean;
+  noticeGroupJid: string | null;
+  noticeGroupName: string | null;
+}

--- a/src/api/entities/user.entity.ts
+++ b/src/api/entities/user.entity.ts
@@ -19,7 +19,7 @@ export class User {
   @Matches(/^[a-zA-Z\s]*$/, { message: 'Name can only contain letters and spaces' })
   name!: string;
 
-  @Column({ nullable: true })
+  @Column({ type: 'varchar', length: 100, nullable: true })
   @IsOptional()
   @IsEmail()
   @MaxLength(100)
@@ -27,8 +27,10 @@ export class User {
 
   @Column()
   @MinLength(8)
-  @MaxLength(20)
-  @Matches(/^(?=.*[A-Za-z])(?=.*\d)[A-Za-z\d]{8,}$/, { message: 'Password must be at least 8 characters long and contain both letters and numbers' })
+  @MaxLength(100)
+  @Matches(/^(?=.*[A-Z])(?=.*\d)(?=.*[^A-Za-z0-9])(?=\S+$).{8,100}$/, {
+    message: 'Password must have at least 8 chars, one uppercase letter, one number, and one special character',
+  })
   password!: string;
 
   @Column()
@@ -62,4 +64,11 @@ export class User {
 
   @Column({ type: 'timestamptz', nullable: true })
   emailVerificationExpiresAt?: Date | null;
+
+  @Index('IDX_user_passwordResetTokenHash')
+  @Column({ type: 'varchar', length: 255, nullable: true })
+  passwordResetTokenHash?: string | null;
+
+  @Column({ type: 'timestamptz', nullable: true })
+  passwordResetExpiresAt?: Date | null;
 }

--- a/src/api/entities/user.entity.ts
+++ b/src/api/entities/user.entity.ts
@@ -1,5 +1,5 @@
-import { Entity, PrimaryGeneratedColumn, Column, Unique } from 'typeorm';
-import { IsEmail, IsString, Matches, MaxLength, MinLength } from 'class-validator';
+import { Entity, PrimaryGeneratedColumn, Column, Index, Unique } from 'typeorm';
+import { IsEmail, IsOptional, IsString, Matches, MaxLength, MinLength } from 'class-validator';
 
 export enum UserRole {
   ADMIN = 'admin',
@@ -19,10 +19,11 @@ export class User {
   @Matches(/^[a-zA-Z\s]*$/, { message: 'Name can only contain letters and spaces' })
   name!: string;
 
-  @Column()
+  @Column({ nullable: true })
+  @IsOptional()
   @IsEmail()
   @MaxLength(100)
-  email!: string;
+  email?: string | null;
 
   @Column()
   @MinLength(8)
@@ -45,4 +46,20 @@ export class User {
 
   @Column({ type: 'uuid' })
   organizationId!: string;
+
+  @Column({ type: 'timestamptz', nullable: true })
+  emailVerifiedAt?: Date | null;
+
+  @Column({ type: 'boolean', default: false })
+  mustChangePassword?: boolean;
+
+  @Column({ type: 'varchar', length: 100, nullable: true })
+  pendingEmail?: string | null;
+
+  @Index('IDX_user_emailVerificationTokenHash')
+  @Column({ type: 'varchar', length: 255, nullable: true })
+  emailVerificationTokenHash?: string | null;
+
+  @Column({ type: 'timestamptz', nullable: true })
+  emailVerificationExpiresAt?: Date | null;
 }

--- a/src/api/services/message.service.ts
+++ b/src/api/services/message.service.ts
@@ -1,0 +1,96 @@
+import { Injectable } from '@nestjs/common';
+import { HttpServiceWrapper } from '../../shared/http/http.service';
+import { WinstonLoggerService } from '../../shared/logger/winston-logger.service';
+import {
+  ContactEmailSettingsDto,
+  CreateContactMessageDto,
+  CreateMessageReplyDto,
+  MessageDto,
+  MessageListResponseDto,
+  MessageReplyDto,
+  MessageUnreadStateDto,
+  UpdateContactEmailSettingsDto,
+} from '../dto/message.dto';
+
+@Injectable()
+export class MessageService {
+  private readonly logger = new WinstonLoggerService();
+  private readonly apiUrl = 'messages';
+
+  constructor(private readonly httpService: HttpServiceWrapper) {}
+
+  async createContactMessage(body: CreateContactMessageDto, token: string): Promise<MessageDto> {
+    try {
+      return await this.httpService.post(`${this.apiUrl}/contact`, body, token);
+    } catch (error) {
+      this.logger.error(`Error in createContactMessage: ${error.message}`);
+      throw error;
+    }
+  }
+
+  async getAdminMessages(token: string, query: Record<string, unknown>): Promise<MessageListResponseDto> {
+    try {
+      return await this.httpService.get(`${this.apiUrl}/admin`, query, token);
+    } catch (error) {
+      this.logger.error(`Error in getAdminMessages: ${error.message}`);
+      throw error;
+    }
+  }
+
+  async getUnreadCount(token: string): Promise<MessageUnreadStateDto> {
+    try {
+      return await this.httpService.get(`${this.apiUrl}/unread-count`, undefined, token);
+    } catch (error) {
+      this.logger.error(`Error in getUnreadCount: ${error.message}`);
+      throw error;
+    }
+  }
+
+  async markAsRead(id: string, token: string): Promise<MessageDto> {
+    try {
+      return await this.httpService.post(`${this.apiUrl}/${id}/mark-read`, {}, token);
+    } catch (error) {
+      this.logger.error(`Error in markAsRead: ${error.message}`);
+      throw error;
+    }
+  }
+
+  async replyAsAdmin(id: string, body: CreateMessageReplyDto, token: string): Promise<MessageReplyDto> {
+    try {
+      return await this.httpService.post(`${this.apiUrl}/${id}/replies`, body, token);
+    } catch (error) {
+      this.logger.error(`Error in replyAsAdmin: ${error.message}`);
+      throw error;
+    }
+  }
+
+  async deleteMessage(id: string, token: string): Promise<{ success: true }> {
+    try {
+      return await this.httpService.delete(`${this.apiUrl}/${id}`, token);
+    } catch (error) {
+      this.logger.error(`Error in deleteMessage: ${error.message}`);
+      throw error;
+    }
+  }
+
+  async getContactEmailSettings(token: string): Promise<ContactEmailSettingsDto> {
+    try {
+      return await this.httpService.get(`${this.apiUrl}/settings/contact-email`, undefined, token);
+    } catch (error) {
+      this.logger.error(`Error in getContactEmailSettings: ${error.message}`);
+      throw error;
+    }
+  }
+
+  async updateContactEmailSettings(
+    body: UpdateContactEmailSettingsDto,
+    token: string,
+  ): Promise<ContactEmailSettingsDto> {
+    try {
+      return await this.httpService.put(`${this.apiUrl}/settings/contact-email`, body, token);
+    } catch (error) {
+      this.logger.error(`Error in updateContactEmailSettings: ${error.message}`);
+      throw error;
+    }
+  }
+}

--- a/src/api/services/notice.service.ts
+++ b/src/api/services/notice.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import { HttpServiceWrapper } from '../../shared/http/http.service';
 import { WinstonLoggerService } from '../../shared/logger/winston-logger.service';
-import { CreateNoticeDto, NoticeDto } from '../dto/notice.dto';
+import { CreateNoticeDto, NoticeDto, NoticeUnreadStateDto } from '../dto/notice.dto';
 
 @Injectable()
 export class NoticeService {
@@ -37,7 +37,7 @@ export class NoticeService {
     }
   }
 
-  async getUnreadCount(token: string) {
+  async getUnreadCount(token: string): Promise<NoticeUnreadStateDto> {
     try {
       return await this.httpService.get(`${this.apiUrl}/unread-count`, undefined, token);
     } catch (error) {

--- a/src/api/services/user.service.auth-regression.spec.ts
+++ b/src/api/services/user.service.auth-regression.spec.ts
@@ -75,6 +75,14 @@ describe('Phase 5 - BFF auth regression flow', () => {
 
   const httpService = {
     post: jest.fn(async () => ({ message: 'Logout successful' })),
+    get: jest.fn(async () => ({
+      onboarding: {
+        mustProvideEmail: false,
+        mustVerifyEmail: false,
+        mustChangePassword: false,
+        onboardingRequired: false,
+      },
+    })),
   };
 
   const jwtService = {
@@ -132,6 +140,7 @@ describe('Phase 5 - BFF auth regression flow', () => {
       revokedTokenRepository as any,
       securityObservability as any,
       requestContextService as any,
+      httpService as any,
     );
   });
 
@@ -148,6 +157,10 @@ describe('Phase 5 - BFF auth regression flow', () => {
       token: 'phase5-token-user-1',
       access_token: 'phase5-token-user-1',
       exp: nowSeconds + 3600,
+      mustProvideEmail: false,
+      mustVerifyEmail: false,
+      mustChangePassword: false,
+      onboardingRequired: false,
     });
 
     await expect(guard.canActivate(createContext(loginResult.access_token))).resolves.toBe(true);

--- a/src/api/services/user.service.ts
+++ b/src/api/services/user.service.ts
@@ -43,12 +43,17 @@ export class UserService {
   async register(createUserDto: CreateUserDto) {
     this.logger.log(`Registering user: ${createUserDto.email}, organization slug: ${createUserDto.organizationSlug}`);
     const organization = await this.resolveOrganizationBySlug(createUserDto.organizationSlug);
+    const normalizedEmail = createUserDto.email?.trim().toLowerCase() || null;
+    const duplicateWhere: Array<{ apartment: string; block: number; organizationId: string } | { email: string; organizationId: string }> = [
+      { apartment: createUserDto.apartment, block: createUserDto.block, organizationId: organization.id },
+    ];
+
+    if (normalizedEmail) {
+      duplicateWhere.push({ email: normalizedEmail, organizationId: organization.id });
+    }
 
     const userExists = await this.userRepository.findOne({
-      where: [
-        { email: createUserDto.email, organizationId: organization.id },
-        { apartment: createUserDto.apartment, block: createUserDto.block, organizationId: organization.id },
-      ],
+      where: duplicateWhere,
     });
     
     if (userExists) {
@@ -59,6 +64,7 @@ export class UserService {
     const hashedPassword = await this.authService.hashPassword(createUserDto.password);
     const newUser = this.userRepository.create({
       ...userPayload,
+      email: normalizedEmail,
       password: hashedPassword,
       organizationId: organization.id,
     });

--- a/src/api/services/user.service.ts
+++ b/src/api/services/user.service.ts
@@ -15,6 +15,12 @@ import { UpdateUserDto } from '../dto/update-user.dto';
 import { User } from '../entities/user.entity';
 import { RevokedToken } from '../entities/revoked-token.entity';
 import { OrganizationService } from './organization.service';
+import {
+  ChangeOnboardingPasswordDto,
+  OnboardingFlagsDto,
+  SetOnboardingEmailDto,
+  VerifyOnboardingEmailDto,
+} from '../dto/onboarding.dto';
 
 @Injectable()
 export class UserService {
@@ -98,16 +104,33 @@ export class UserService {
     const payload = { name: user.name, id: user.id, role: user.role, organizationId: organization.id };
     const token = this.authService.generateToken(payload);
     const decoded = this.authService.decodeToken(token);
+    const onboarding = await this.resolveOnboardingFlags(token, user);
 
     this.logger.log(`User logged in successfully: ${user.email}`);
-    return { message: 'User logged in successfully', token, access_token: token, exp: decoded?.exp };
+    return {
+      message: 'User logged in successfully',
+      token,
+      access_token: token,
+      exp: decoded?.exp,
+      ...onboarding,
+    };
   }
 
   async getProfile(token: string) {
     this.logger.log('Entering UserService.getProfile');
 
     this.logger.log('Redirecting GET profile request to API');
-    return this.httpService.get('users/profile', undefined, token);
+    const response = await this.httpService.get<{
+      message: string;
+      user: Record<string, unknown>;
+      onboarding?: OnboardingFlagsDto;
+    }>('users/profile', undefined, token);
+
+    const onboarding = response?.onboarding ?? this.defaultOnboardingFlags();
+    return {
+      ...response,
+      ...onboarding,
+    };
   }
 
   async getAllUsers(token: string) {
@@ -164,6 +187,18 @@ export class UserService {
     return this.httpService.delete(`users/${userId}`, token);
   }
 
+  async setOnboardingEmail(data: SetOnboardingEmailDto, token: string) {
+    return this.httpService.post('users/onboarding/email', data, token);
+  }
+
+  async verifyOnboardingEmail(data: VerifyOnboardingEmailDto, token: string) {
+    return this.httpService.post('users/onboarding/verify', data, token);
+  }
+
+  async changeOnboardingPassword(data: ChangeOnboardingPasswordDto, token: string) {
+    return this.httpService.post('users/onboarding/change-password', data, token);
+  }
+
   private async resolveOrganizationBySlug(slug: string): Promise<{ id: string; slug: string; name: string }> {
     try {
       return await this.organizationService.findBySlug(slug);
@@ -173,5 +208,39 @@ export class UserService {
       }
       throw error;
     }
+  }
+
+  private async resolveOnboardingFlags(token: string, fallbackUser: User): Promise<OnboardingFlagsDto> {
+    try {
+      const profileResponse = await this.httpService.get<{
+        onboarding?: OnboardingFlagsDto;
+      }>('users/profile', undefined, token);
+      return profileResponse?.onboarding ?? this.deriveOnboardingFlagsFromUser(fallbackUser);
+    } catch (error) {
+      this.logger.warn('Failed to fetch onboarding flags from API, using local fallback');
+      return this.deriveOnboardingFlagsFromUser(fallbackUser);
+    }
+  }
+
+  private deriveOnboardingFlagsFromUser(user: User): OnboardingFlagsDto {
+    const hasVerifiedActiveEmail = Boolean(user.email && user.emailVerifiedAt);
+    const mustProvideEmail = !user.email && !user.pendingEmail;
+    const mustVerifyEmail = !hasVerifiedActiveEmail && !mustProvideEmail;
+    const mustChangePassword = Boolean(user.mustChangePassword);
+    return {
+      mustProvideEmail,
+      mustVerifyEmail,
+      mustChangePassword,
+      onboardingRequired: !hasVerifiedActiveEmail || mustChangePassword,
+    };
+  }
+
+  private defaultOnboardingFlags(): OnboardingFlagsDto {
+    return {
+      mustProvideEmail: false,
+      mustVerifyEmail: false,
+      mustChangePassword: false,
+      onboardingRequired: false,
+    };
   }
 }

--- a/src/api/services/user.service.ts
+++ b/src/api/services/user.service.ts
@@ -12,10 +12,12 @@ import { HttpServiceWrapper } from '../../shared/http/http.service';
 import { CreateUserDto } from '../dto/create-user.dto';
 import { LoginUserDto } from '../dto/login-user.dto';
 import { UpdateUserDto } from '../dto/update-user.dto';
+import { ForgotPasswordConfirmDto, ForgotPasswordRequestDto } from '../dto/forgot-password.dto';
 import { User } from '../entities/user.entity';
 import { RevokedToken } from '../entities/revoked-token.entity';
 import { OrganizationService } from './organization.service';
 import {
+  ChangePasswordDto,
   ChangeOnboardingPasswordDto,
   OnboardingFlagsDto,
   SetOnboardingEmailDto,
@@ -197,6 +199,18 @@ export class UserService {
 
   async changeOnboardingPassword(data: ChangeOnboardingPasswordDto, token: string) {
     return this.httpService.post('users/onboarding/change-password', data, token);
+  }
+
+  async changePassword(data: ChangePasswordDto, token: string) {
+    return this.httpService.put('users/change-password', data, token);
+  }
+
+  async requestForgotPassword(data: ForgotPasswordRequestDto) {
+    return this.httpService.post('users/forgot-password/request', data);
+  }
+
+  async confirmForgotPassword(data: ForgotPasswordConfirmDto) {
+    return this.httpService.post('users/forgot-password/confirm', data);
   }
 
   private async resolveOrganizationBySlug(slug: string): Promise<{ id: string; slug: string; name: string }> {

--- a/src/api/services/user.service.ts
+++ b/src/api/services/user.service.ts
@@ -118,6 +118,14 @@ export class UserService {
     return this.httpService.put('users/profile', updateData, token);
   }
 
+  async updateUser(userId: string, updateData: UpdateUserDto, token: string) {
+    this.logger.log('Entering UserService.updateUser');
+    this.logger.log(`User ID to update: ${userId}`);
+    this.logger.log('Redirecting PUT user update request to API');
+
+    return this.httpService.put(`users/${userId}`, updateData, token);
+  }
+
   async logout(token: string) {
     this.logger.log('Entering UserService.logout');
     const decoded = this.authService.decodeToken(token);

--- a/src/api/services/user.service.ts
+++ b/src/api/services/user.service.ts
@@ -103,10 +103,10 @@ export class UserService {
       throw new UnauthorizedException('Invalid credentials');
     }
 
-    const payload = { name: user.name, id: user.id, role: user.role, organizationId: organization.id };
+    const onboarding = this.resolveOnboardingFlags(user);
+    const payload = { name: user.name, id: user.id, role: user.role, organizationId: organization.id, onboarding };
     const token = this.authService.generateToken(payload);
     const decoded = this.authService.decodeToken(token);
-    const onboarding = this.resolveOnboardingFlags(user);
 
     this.logger.log(`User logged in successfully: ${user.email}`);
     return {

--- a/src/api/services/user.service.ts
+++ b/src/api/services/user.service.ts
@@ -106,7 +106,7 @@ export class UserService {
     const payload = { name: user.name, id: user.id, role: user.role, organizationId: organization.id };
     const token = this.authService.generateToken(payload);
     const decoded = this.authService.decodeToken(token);
-    const onboarding = await this.resolveOnboardingFlags(token, user);
+    const onboarding = this.resolveOnboardingFlags(user);
 
     this.logger.log(`User logged in successfully: ${user.email}`);
     return {
@@ -131,7 +131,7 @@ export class UserService {
     const onboarding = response?.onboarding ?? this.defaultOnboardingFlags();
     return {
       ...response,
-      ...onboarding,
+      onboarding,
     };
   }
 
@@ -224,16 +224,8 @@ export class UserService {
     }
   }
 
-  private async resolveOnboardingFlags(token: string, fallbackUser: User): Promise<OnboardingFlagsDto> {
-    try {
-      const profileResponse = await this.httpService.get<{
-        onboarding?: OnboardingFlagsDto;
-      }>('users/profile', undefined, token);
-      return profileResponse?.onboarding ?? this.deriveOnboardingFlagsFromUser(fallbackUser);
-    } catch (error) {
-      this.logger.warn('Failed to fetch onboarding flags from API, using local fallback');
-      return this.deriveOnboardingFlagsFromUser(fallbackUser);
-    }
+  private resolveOnboardingFlags(fallbackUser: User): OnboardingFlagsDto {
+    return this.deriveOnboardingFlagsFromUser(fallbackUser);
   }
 
   private deriveOnboardingFlagsFromUser(user: User): OnboardingFlagsDto {

--- a/src/api/services/user.service.ts
+++ b/src/api/services/user.service.ts
@@ -67,6 +67,7 @@ export class UserService {
       email: normalizedEmail,
       password: hashedPassword,
       organizationId: organization.id,
+      mustChangePassword: true,
     });
 
     await this.userRepository.save(newUser);

--- a/src/api/services/whatsapp-settings.service.ts
+++ b/src/api/services/whatsapp-settings.service.ts
@@ -1,0 +1,82 @@
+import { Injectable } from '@nestjs/common';
+import { HttpServiceWrapper } from '../../shared/http/http.service';
+import { WinstonLoggerService } from '../../shared/logger/winston-logger.service';
+import {
+  TestWhatsappConnectionDto,
+  UpdateWhatsappSettingsDto,
+  UpsertWhatsappGroupBindingDto,
+  WhatsappGroupBindingDto,
+  WhatsappGroupOptionDto,
+  WhatsappSettingsViewDto,
+} from '../dto/whatsapp-settings.dto';
+
+@Injectable()
+export class WhatsappSettingsService {
+  private readonly logger = new WinstonLoggerService();
+  private readonly apiUrl = 'whatsapp/settings';
+
+  constructor(private readonly httpService: HttpServiceWrapper) {}
+
+  async getSettings(token: string): Promise<WhatsappSettingsViewDto> {
+    try {
+      return await this.httpService.get(this.apiUrl, undefined, token);
+    } catch (error) {
+      this.logger.error(`Error in getSettings: ${error.message}`);
+      throw error;
+    }
+  }
+
+  async updateSettings(body: UpdateWhatsappSettingsDto, token: string): Promise<WhatsappSettingsViewDto> {
+    try {
+      return await this.httpService.put(this.apiUrl, body, token);
+    } catch (error) {
+      this.logger.error(`Error in updateSettings: ${error.message}`);
+      throw error;
+    }
+  }
+
+  async bootstrapLegacy(token: string): Promise<WhatsappSettingsViewDto> {
+    try {
+      return await this.httpService.post(`${this.apiUrl}/bootstrap-legacy`, {}, token);
+    } catch (error) {
+      this.logger.error(`Error in bootstrapLegacy: ${error.message}`);
+      throw error;
+    }
+  }
+
+  async testConnection(body: TestWhatsappConnectionDto, token: string): Promise<{ ok: boolean; statusCode: number | null }> {
+    try {
+      return await this.httpService.post(`${this.apiUrl}/test-connection`, body, token);
+    } catch (error) {
+      this.logger.error(`Error in testConnection: ${error.message}`);
+      throw error;
+    }
+  }
+
+  async getGroups(token: string): Promise<WhatsappGroupOptionDto[]> {
+    try {
+      return await this.httpService.get(`${this.apiUrl}/groups`, undefined, token);
+    } catch (error) {
+      this.logger.error(`Error in getGroups: ${error.message}`);
+      throw error;
+    }
+  }
+
+  async getBindings(token: string): Promise<WhatsappGroupBindingDto[]> {
+    try {
+      return await this.httpService.get(`${this.apiUrl}/bindings`, undefined, token);
+    } catch (error) {
+      this.logger.error(`Error in getBindings: ${error.message}`);
+      throw error;
+    }
+  }
+
+  async upsertBinding(feature: string, body: UpsertWhatsappGroupBindingDto, token: string): Promise<WhatsappGroupBindingDto> {
+    try {
+      return await this.httpService.put(`${this.apiUrl}/bindings/${feature}`, body, token);
+    } catch (error) {
+      this.logger.error(`Error in upsertBinding: ${error.message}`);
+      throw error;
+    }
+  }
+}

--- a/src/shared/auth/guards/jwt-auth.guard.spec.ts
+++ b/src/shared/auth/guards/jwt-auth.guard.spec.ts
@@ -1,4 +1,4 @@
-import { ExecutionContext, ForbiddenException, UnauthorizedException } from '@nestjs/common';
+import { ExecutionContext, ForbiddenException, ServiceUnavailableException, UnauthorizedException } from '@nestjs/common';
 import { JwtAuthGuard } from './jwt-auth.guard';
 
 const BFF_PROTECTED_PATHS = ['/users/profile', '/users', '/resources', '/bookings', '/bookeddates', '/notices', '/messages'];
@@ -160,5 +160,12 @@ describe('BFF JwtAuthGuard - Phase 2 revocation enforcement', () => {
       'invalid_token_payload',
       '/users/profile',
     );
+  });
+
+  it('returns service unavailable when onboarding profile lookup fails', async () => {
+    revokedTokenRepository.findOne.mockResolvedValue(null);
+    httpService.get.mockRejectedValue(new Error('upstream timeout'));
+
+    await expect(guard.canActivate(createContext('/users/profile'))).rejects.toThrow(ServiceUnavailableException);
   });
 });

--- a/src/shared/auth/guards/jwt-auth.guard.spec.ts
+++ b/src/shared/auth/guards/jwt-auth.guard.spec.ts
@@ -1,7 +1,7 @@
 import { ExecutionContext, ForbiddenException, UnauthorizedException } from '@nestjs/common';
 import { JwtAuthGuard } from './jwt-auth.guard';
 
-const BFF_PROTECTED_PATHS = ['/users/profile', '/users', '/resources', '/bookings', '/notices', '/messages'];
+const BFF_PROTECTED_PATHS = ['/users/profile', '/users', '/resources', '/bookings', '/bookeddates', '/notices', '/messages'];
 
 describe('BFF JwtAuthGuard - Phase 2 revocation enforcement', () => {
   const token = 'phase2-token';

--- a/src/shared/auth/guards/jwt-auth.guard.spec.ts
+++ b/src/shared/auth/guards/jwt-auth.guard.spec.ts
@@ -1,7 +1,7 @@
 import { ExecutionContext, ForbiddenException, UnauthorizedException } from '@nestjs/common';
 import { JwtAuthGuard } from './jwt-auth.guard';
 
-const BFF_PROTECTED_PATHS = ['/users/profile', '/users', '/resources', '/bookings', '/notices'];
+const BFF_PROTECTED_PATHS = ['/users/profile', '/users', '/resources', '/bookings', '/notices', '/messages'];
 
 describe('BFF JwtAuthGuard - Phase 2 revocation enforcement', () => {
   const token = 'phase2-token';

--- a/src/shared/auth/guards/jwt-auth.guard.spec.ts
+++ b/src/shared/auth/guards/jwt-auth.guard.spec.ts
@@ -19,6 +19,9 @@ describe('BFF JwtAuthGuard - Phase 2 revocation enforcement', () => {
   const requestContextService = {
     setOrganizationId: jest.fn(),
   };
+  const httpService = {
+    get: jest.fn(),
+  };
 
   let guard: JwtAuthGuard;
 
@@ -54,6 +57,7 @@ describe('BFF JwtAuthGuard - Phase 2 revocation enforcement', () => {
       revokedTokenRepository as any,
       securityObservability as any,
       requestContextService as any,
+      httpService as any,
     );
     jwtService.verify.mockReturnValue({
       sub: 'user-1',
@@ -61,6 +65,14 @@ describe('BFF JwtAuthGuard - Phase 2 revocation enforcement', () => {
       role: 'resident',
       organizationId: '4f5a8d5b-6fd0-4da0-bf96-c2454c6f8c99',
       exp: Math.floor(Date.now() / 1000) + 3600,
+    });
+    httpService.get.mockResolvedValue({
+      onboarding: {
+        mustProvideEmail: false,
+        mustVerifyEmail: false,
+        mustChangePassword: false,
+        onboardingRequired: false,
+      },
     });
   });
 
@@ -118,6 +130,20 @@ describe('BFF JwtAuthGuard - Phase 2 revocation enforcement', () => {
       expect(securityObservability.recordAuthFailure).toHaveBeenCalledWith('invalid_or_expired_token', path);
     },
   );
+
+  it('denies resident restricted sessions on non-onboarding paths', async () => {
+    revokedTokenRepository.findOne.mockResolvedValue(null);
+    httpService.get.mockResolvedValue({
+      onboarding: {
+        mustProvideEmail: true,
+        mustVerifyEmail: false,
+        mustChangePassword: true,
+        onboardingRequired: true,
+      },
+    });
+
+    await expect(guard.canActivate(createContext('/bookings'))).rejects.toThrow(ForbiddenException);
+  });
 
   it('rejects tokens with role outside canonical enum', async () => {
     revokedTokenRepository.findOne.mockResolvedValue(null);

--- a/src/shared/auth/guards/jwt-auth.guard.ts
+++ b/src/shared/auth/guards/jwt-auth.guard.ts
@@ -12,6 +12,7 @@ import { HttpServiceWrapper } from '../../http/http.service';
 @Injectable()
 export class JwtAuthGuard implements CanActivate {
   private readonly logger = new Logger(JwtAuthGuard.name);
+  private static readonly ONBOARDING_CACHE_TTL_MS = 60_000;
   private static readonly CSRF_HEADER = 'x-csrf-token';
   private static readonly ONBOARDING_ALLOWED_PATHS = new Set([
     '/users/profile',
@@ -20,6 +21,18 @@ export class JwtAuthGuard implements CanActivate {
     '/users/onboarding/verify',
     '/users/onboarding/change-password',
   ]);
+  private readonly onboardingCache = new Map<
+    string,
+    {
+      flags: {
+        mustProvideEmail: boolean;
+        mustVerifyEmail: boolean;
+        mustChangePassword: boolean;
+        onboardingRequired: boolean;
+      };
+      expiresAt: number;
+    }
+  >();
 
   constructor(
     private readonly jwtService: JwtService,
@@ -134,6 +147,12 @@ export class JwtAuthGuard implements CanActivate {
       };
     }
 
+    const now = Date.now();
+    const cached = this.onboardingCache.get(token);
+    if (cached && cached.expiresAt > now) {
+      return cached.flags;
+    }
+
     const profile = await this.httpService.get<{
       onboarding?: {
         mustProvideEmail?: boolean;
@@ -144,11 +163,18 @@ export class JwtAuthGuard implements CanActivate {
     }>('users/profile', undefined, token);
 
     const onboarding = profile?.onboarding;
-    return {
+    const flags = {
       mustProvideEmail: Boolean(onboarding?.mustProvideEmail),
       mustVerifyEmail: Boolean(onboarding?.mustVerifyEmail),
       mustChangePassword: Boolean(onboarding?.mustChangePassword),
       onboardingRequired: Boolean(onboarding?.onboardingRequired),
     };
+
+    this.onboardingCache.set(token, {
+      flags,
+      expiresAt: now + JwtAuthGuard.ONBOARDING_CACHE_TTL_MS,
+    });
+
+    return flags;
   }
 }

--- a/src/shared/auth/guards/jwt-auth.guard.ts
+++ b/src/shared/auth/guards/jwt-auth.guard.ts
@@ -1,4 +1,12 @@
-import { Injectable, CanActivate, ExecutionContext, UnauthorizedException, Logger, ForbiddenException } from '@nestjs/common';
+import {
+  Injectable,
+  CanActivate,
+  ExecutionContext,
+  UnauthorizedException,
+  Logger,
+  ForbiddenException,
+  ServiceUnavailableException,
+} from '@nestjs/common';
 import { JwtService } from '@nestjs/jwt';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
@@ -13,6 +21,7 @@ import { HttpServiceWrapper } from '../../http/http.service';
 export class JwtAuthGuard implements CanActivate {
   private readonly logger = new Logger(JwtAuthGuard.name);
   private static readonly ONBOARDING_CACHE_TTL_MS = 60_000;
+  private static readonly ONBOARDING_CACHE_MAX_SIZE = 1000;
   private static readonly CSRF_HEADER = 'x-csrf-token';
   private static readonly ONBOARDING_ALLOWED_PATHS = new Set([
     '/users/profile',
@@ -115,6 +124,9 @@ export class JwtAuthGuard implements CanActivate {
       if (error instanceof ForbiddenException) {
         throw error;
       }
+      if (error instanceof ServiceUnavailableException) {
+        throw error;
+      }
       if (error instanceof UnauthorizedException && error.message === 'Invalid token payload') {
         throw error;
       }
@@ -148,19 +160,33 @@ export class JwtAuthGuard implements CanActivate {
     }
 
     const now = Date.now();
+    this.cleanupOnboardingCache(now);
     const cached = this.onboardingCache.get(token);
     if (cached && cached.expiresAt > now) {
       return cached.flags;
     }
 
-    const profile = await this.httpService.get<{
+    let profile: {
       onboarding?: {
         mustProvideEmail?: boolean;
         mustVerifyEmail?: boolean;
         mustChangePassword?: boolean;
         onboardingRequired?: boolean;
       };
-    }>('users/profile', undefined, token);
+    } | null = null;
+    try {
+      profile = await this.httpService.get<{
+        onboarding?: {
+          mustProvideEmail?: boolean;
+          mustVerifyEmail?: boolean;
+          mustChangePassword?: boolean;
+          onboardingRequired?: boolean;
+        };
+      }>('users/profile', undefined, token);
+    } catch (error) {
+      this.logger.warn(`Unable to resolve onboarding flags from profile service: ${(error as Error).message}`);
+      throw new ServiceUnavailableException('Unable to resolve onboarding status right now');
+    }
 
     const onboarding = profile?.onboarding;
     const flags = {
@@ -174,7 +200,32 @@ export class JwtAuthGuard implements CanActivate {
       flags,
       expiresAt: now + JwtAuthGuard.ONBOARDING_CACHE_TTL_MS,
     });
+    this.enforceOnboardingCacheSizeLimit(now);
 
     return flags;
+  }
+
+  private cleanupOnboardingCache(now: number): void {
+    for (const [key, entry] of this.onboardingCache.entries()) {
+      if (entry.expiresAt <= now) {
+        this.onboardingCache.delete(key);
+      }
+    }
+  }
+
+  private enforceOnboardingCacheSizeLimit(now: number): void {
+    this.cleanupOnboardingCache(now);
+    if (this.onboardingCache.size <= JwtAuthGuard.ONBOARDING_CACHE_MAX_SIZE) {
+      return;
+    }
+
+    const keysIterator = this.onboardingCache.keys();
+    while (this.onboardingCache.size > JwtAuthGuard.ONBOARDING_CACHE_MAX_SIZE) {
+      const next = keysIterator.next();
+      if (next.done) {
+        break;
+      }
+      this.onboardingCache.delete(next.value);
+    }
   }
 }

--- a/src/shared/auth/guards/jwt-auth.guard.ts
+++ b/src/shared/auth/guards/jwt-auth.guard.ts
@@ -22,6 +22,7 @@ export class JwtAuthGuard implements CanActivate {
   private readonly logger = new Logger(JwtAuthGuard.name);
   private static readonly ONBOARDING_CACHE_TTL_MS = 60_000;
   private static readonly ONBOARDING_CACHE_MAX_SIZE = 1000;
+  private static readonly ONBOARDING_CACHE_CLEANUP_INTERVAL_MS = 30_000;
   private static readonly CSRF_HEADER = 'x-csrf-token';
   private static readonly ONBOARDING_ALLOWED_PATHS = new Set([
     '/users/profile',
@@ -42,6 +43,7 @@ export class JwtAuthGuard implements CanActivate {
       expiresAt: number;
     }
   >();
+  private lastOnboardingCacheCleanupAt = 0;
 
   constructor(
     private readonly jwtService: JwtService,
@@ -100,7 +102,7 @@ export class JwtAuthGuard implements CanActivate {
       }
 
       this.requestContextService.setOrganizationId(decoded.organizationId);
-      const onboarding = await this.resolveOnboardingFlags(token, decoded.role);
+      const onboarding = await this.resolveOnboardingFlags(token, decoded.role, decoded);
       const requestPath = this.normalizeRequestPath(request.url);
       if (
         decoded.role === UserRole.RESIDENT
@@ -144,6 +146,14 @@ export class JwtAuthGuard implements CanActivate {
   private async resolveOnboardingFlags(
     token: string,
     role: UserRole,
+    decodedPayload?: {
+      onboarding?: {
+        mustProvideEmail?: boolean;
+        mustVerifyEmail?: boolean;
+        mustChangePassword?: boolean;
+        onboardingRequired?: boolean;
+      };
+    },
   ): Promise<{
     mustProvideEmail: boolean;
     mustVerifyEmail: boolean;
@@ -160,10 +170,20 @@ export class JwtAuthGuard implements CanActivate {
     }
 
     const now = Date.now();
-    this.cleanupOnboardingCache(now);
+    this.maybeCleanupOnboardingCache(now);
     const cached = this.onboardingCache.get(token);
     if (cached && cached.expiresAt > now) {
       return cached.flags;
+    }
+
+    const tokenFlags = this.tryResolveOnboardingFlagsFromToken(decodedPayload);
+    if (tokenFlags) {
+      this.onboardingCache.set(token, {
+        flags: tokenFlags,
+        expiresAt: now + JwtAuthGuard.ONBOARDING_CACHE_TTL_MS,
+      });
+      this.enforceOnboardingCacheSizeLimit(now);
+      return tokenFlags;
     }
 
     let profile: {
@@ -205,16 +225,21 @@ export class JwtAuthGuard implements CanActivate {
     return flags;
   }
 
-  private cleanupOnboardingCache(now: number): void {
+  private maybeCleanupOnboardingCache(now: number, force = false): void {
+    if (!force && now - this.lastOnboardingCacheCleanupAt < JwtAuthGuard.ONBOARDING_CACHE_CLEANUP_INTERVAL_MS) {
+      return;
+    }
+
     for (const [key, entry] of this.onboardingCache.entries()) {
       if (entry.expiresAt <= now) {
         this.onboardingCache.delete(key);
       }
     }
+    this.lastOnboardingCacheCleanupAt = now;
   }
 
   private enforceOnboardingCacheSizeLimit(now: number): void {
-    this.cleanupOnboardingCache(now);
+    this.maybeCleanupOnboardingCache(now, true);
     if (this.onboardingCache.size <= JwtAuthGuard.ONBOARDING_CACHE_MAX_SIZE) {
       return;
     }
@@ -227,5 +252,31 @@ export class JwtAuthGuard implements CanActivate {
       }
       this.onboardingCache.delete(next.value);
     }
+  }
+
+  private tryResolveOnboardingFlagsFromToken(decodedPayload?: {
+    onboarding?: {
+      mustProvideEmail?: boolean;
+      mustVerifyEmail?: boolean;
+      mustChangePassword?: boolean;
+      onboardingRequired?: boolean;
+    };
+  }): {
+    mustProvideEmail: boolean;
+    mustVerifyEmail: boolean;
+    mustChangePassword: boolean;
+    onboardingRequired: boolean;
+  } | null {
+    const onboarding = decodedPayload?.onboarding;
+    if (!onboarding || typeof onboarding !== 'object') {
+      return null;
+    }
+
+    return {
+      mustProvideEmail: Boolean(onboarding.mustProvideEmail),
+      mustVerifyEmail: Boolean(onboarding.mustVerifyEmail),
+      mustChangePassword: Boolean(onboarding.mustChangePassword),
+      onboardingRequired: Boolean(onboarding.onboardingRequired),
+    };
   }
 }

--- a/src/shared/auth/guards/jwt-auth.guard.ts
+++ b/src/shared/auth/guards/jwt-auth.guard.ts
@@ -7,11 +7,19 @@ import { UserRole } from '../../../api/entities/user.entity';
 import { getAuthTokenFromCookieHeader, getCsrfTokenFromCookieHeader } from '../auth-cookie.util';
 import { SecurityObservabilityService } from '../../security/security-observability.service';
 import { RequestContextService } from '../../request-context/request-context.service';
+import { HttpServiceWrapper } from '../../http/http.service';
 
 @Injectable()
 export class JwtAuthGuard implements CanActivate {
   private readonly logger = new Logger(JwtAuthGuard.name);
   private static readonly CSRF_HEADER = 'x-csrf-token';
+  private static readonly ONBOARDING_ALLOWED_PATHS = new Set([
+    '/users/profile',
+    '/users/logout',
+    '/users/onboarding/email',
+    '/users/onboarding/verify',
+    '/users/onboarding/change-password',
+  ]);
 
   constructor(
     private readonly jwtService: JwtService,
@@ -19,6 +27,7 @@ export class JwtAuthGuard implements CanActivate {
     private readonly revokedTokenRepository: Repository<RevokedToken>,
     private readonly securityObservability: SecurityObservabilityService,
     private readonly requestContextService: RequestContextService,
+    private readonly httpService: HttpServiceWrapper,
   ) {}
 
   async canActivate(context: ExecutionContext): Promise<boolean> {
@@ -69,15 +78,30 @@ export class JwtAuthGuard implements CanActivate {
       }
 
       this.requestContextService.setOrganizationId(decoded.organizationId);
+      const onboarding = await this.resolveOnboardingFlags(token, decoded.role);
+      const requestPath = this.normalizeRequestPath(request.url);
+      if (
+        decoded.role === UserRole.RESIDENT
+        && onboarding.onboardingRequired
+        && !JwtAuthGuard.ONBOARDING_ALLOWED_PATHS.has(requestPath)
+      ) {
+        this.logger.warn(`Blocked restricted session path: ${requestPath}`);
+        throw new ForbiddenException('Complete onboarding before accessing this route');
+      }
+
       request.user = {
         id: decoded.sub,
         name: decoded.name,
         role: decoded.role,
         organizationId: decoded.organizationId,
         token,
+        ...onboarding,
       };
       return true;
     } catch (error) {
+      if (error instanceof ForbiddenException) {
+        throw error;
+      }
       if (error instanceof UnauthorizedException && error.message === 'Invalid token payload') {
         throw error;
       }
@@ -85,5 +109,46 @@ export class JwtAuthGuard implements CanActivate {
       this.securityObservability.recordAuthFailure('invalid_or_expired_token', request.url);
       throw new UnauthorizedException('Invalid or expired token');
     }
+  }
+
+  private normalizeRequestPath(url: string): string {
+    const [path] = (url || '').split('?');
+    return path || '/';
+  }
+
+  private async resolveOnboardingFlags(
+    token: string,
+    role: UserRole,
+  ): Promise<{
+    mustProvideEmail: boolean;
+    mustVerifyEmail: boolean;
+    mustChangePassword: boolean;
+    onboardingRequired: boolean;
+  }> {
+    if (role !== UserRole.RESIDENT) {
+      return {
+        mustProvideEmail: false,
+        mustVerifyEmail: false,
+        mustChangePassword: false,
+        onboardingRequired: false,
+      };
+    }
+
+    const profile = await this.httpService.get<{
+      onboarding?: {
+        mustProvideEmail?: boolean;
+        mustVerifyEmail?: boolean;
+        mustChangePassword?: boolean;
+        onboardingRequired?: boolean;
+      };
+    }>('users/profile', undefined, token);
+
+    const onboarding = profile?.onboarding;
+    return {
+      mustProvideEmail: Boolean(onboarding?.mustProvideEmail),
+      mustVerifyEmail: Boolean(onboarding?.mustVerifyEmail),
+      mustChangePassword: Boolean(onboarding?.mustChangePassword),
+      onboardingRequired: Boolean(onboarding?.onboardingRequired),
+    };
   }
 }

--- a/src/shared/auth/services/auth.service.ts
+++ b/src/shared/auth/services/auth.service.ts
@@ -14,12 +14,24 @@ export class AuthService {
     return bcrypt.compare(password, hashedPassword);
   }
 
-  generateToken(payload: { name: string; id: string; role: string; organizationId: string }): string {
+  generateToken(payload: {
+    name: string;
+    id: string;
+    role: string;
+    organizationId: string;
+    onboarding?: {
+      mustProvideEmail: boolean;
+      mustVerifyEmail: boolean;
+      mustChangePassword: boolean;
+      onboardingRequired: boolean;
+    };
+  }): string {
     const tokenPayload = {
       name: payload.name,
       sub: payload.id,
       role: payload.role,
       organizationId: payload.organizationId,
+      ...(payload.onboarding ? { onboarding: payload.onboarding } : {}),
     };
 
     const token = this.jwtService.sign(tokenPayload);

--- a/src/shared/validation/password-policy.ts
+++ b/src/shared/validation/password-policy.ts
@@ -1,0 +1,4 @@
+export const PASSWORD_POLICY_REGEX = /^(?=.*[A-Z])(?=.*\d)(?=.*[^A-Za-z0-9])(?=\S+$).{8,100}$/;
+
+export const PASSWORD_POLICY_MESSAGE =
+  'Password must have at least 8 chars, one uppercase letter, one number, and one special character';


### PR DESCRIPTION
This pull request introduces a new WhatsApp Settings feature to the API, including endpoints, service logic, and DTOs for managing WhatsApp integration and group bindings. It also refines the unread notices API to return a more structured response. The main changes are grouped below.

**WhatsApp Settings Feature:**

* Added a new `WhatsappSettingsController` with endpoints for managing WhatsApp settings, testing connections, bootstrapping legacy setup, and handling group bindings. Access to these endpoints is restricted to admin users.
* Implemented `WhatsappSettingsService` to handle API calls related to WhatsApp settings, group management, and connection testing, with structured error logging.
* Introduced a comprehensive set of DTOs in `whatsapp-settings.dto.ts` for updating settings, testing connections, managing group bindings, and representing WhatsApp settings state.
* Registered the new controller and service in the `api.module.ts` module configuration. [[1]](diffhunk://#diff-9f7803d7cfd3dd9b7175b454afff77627e7bf89544b5ee4ac0320b9309900e87R19-R20) [[2]](diffhunk://#diff-9f7803d7cfd3dd9b7175b454afff77627e7bf89544b5ee4ac0320b9309900e87L30-R40)

**Unread Notices API Improvement:**

* Updated the unread notices API to return a `NoticeUnreadStateDto` object (with `hasUnread` and `lastSeenNoticesAt`), improving type safety and clarity for consumers. This involved changes to the DTO, controller, and service. [[1]](diffhunk://#diff-7dd8c3f32f9cc8fc64a0a7f1a2b8819fa98c39cef363dde6c7f750b8e7ff5c4aR32-R36) [[2]](diffhunk://#diff-3e4ec88eca07ecc2bc56e6e369c586846962cd98c338950ca4c75c5092f42bb3R18) [[3]](diffhunk://#diff-3e4ec88eca07ecc2bc56e6e369c586846962cd98c338950ca4c75c5092f42bb3L57-R58) [[4]](diffhunk://#diff-f241c581c2e531c527bf16e7f8d3f9fee74cc86bb405c879d4719bf057bfd608L4-R4) [[5]](diffhunk://#diff-f241c581c2e531c527bf16e7f8d3f9fee74cc86bb405c879d4719bf057bfd608L40-R40)