### PR TITLE
Add resident message handling methods for messaging functionality

### DIFF
--- a/src/api/controllers/message.controller.spec.ts
+++ b/src/api/controllers/message.controller.spec.ts
@@ -18,9 +18,11 @@ describe('BFF MessageController', () => {
           useValue: {
             createContactMessage: jest.fn(),
             getAdminMessages: jest.fn(),
+            getResidentMessages: jest.fn(),
             getUnreadCount: jest.fn(),
             markAsRead: jest.fn(),
             replyAsAdmin: jest.fn(),
+            replyAsResident: jest.fn(),
             deleteMessage: jest.fn(),
             getContactEmailSettings: jest.fn(),
             updateContactEmailSettings: jest.fn(),

--- a/src/api/controllers/message.controller.spec.ts
+++ b/src/api/controllers/message.controller.spec.ts
@@ -73,6 +73,32 @@ describe('BFF MessageController', () => {
     ).rejects.toThrow(ForbiddenException);
   });
 
+  it('proxies resident inbox for resident users', async () => {
+    service.getResidentMessages.mockResolvedValue({ data: [], total: 0, page: 1, lastPage: 1 });
+
+    await expect(
+      controller.getResidentMessages({ user: { role: UserRole.RESIDENT, token: 'jwt-token' } } as any, {}),
+    ).resolves.toEqual({ data: [], total: 0, page: 1, lastPage: 1 });
+
+    expect(service.getResidentMessages).toHaveBeenCalledWith('jwt-token', {});
+  });
+
+  it('rejects resident inbox for admin users', async () => {
+    await expect(
+      controller.getResidentMessages({ user: { role: UserRole.ADMIN, token: 'jwt-token' } } as any, {}),
+    ).rejects.toThrow(ForbiddenException);
+  });
+
+  it('rejects resident reply without token', async () => {
+    await expect(
+      controller.replyAsResident(
+        '11111111-1111-4111-8111-111111111111',
+        { content: 'reply' } as any,
+        { user: { role: UserRole.RESIDENT } } as any,
+      ),
+    ).rejects.toThrow(UnauthorizedException);
+  });
+
   it('rejects contact email settings update without token', async () => {
     await expect(
       controller.updateContactEmailSettings(

--- a/src/api/controllers/message.controller.ts
+++ b/src/api/controllers/message.controller.ts
@@ -63,17 +63,7 @@ export class MessageController {
   @Get('mine')
   async getResidentMessages(@Req() req: any, @Query() query: Record<string, unknown>): Promise<MessageListResponseDto> {
     this.logger.log('Received GET /messages/mine request');
-    const token = req.user?.token;
-
-    if (!token) {
-      this.logger.error('Authorization token is missing in the request');
-      throw new UnauthorizedException('Authorization token is missing');
-    }
-
-    if (req.user?.role !== UserRole.RESIDENT) {
-      this.logger.error('User does not have resident permissions to perform this action');
-      throw new ForbiddenException('You do not have permission to perform this action');
-    }
+    const token = this.ensureResidentAndGetToken(req);
 
     return this.messageService.getResidentMessages(token, query);
   }
@@ -119,17 +109,7 @@ export class MessageController {
   @Post(':id/replies/mine')
   async replyAsResident(@Param('id', new ParseUUIDPipe()) id: string, @Body(new JoiValidationPipe(CreateMessageReplySchema)) body: CreateMessageReplyDto, @Req() req: any) {
     this.logger.log(`Received POST /messages/${id}/replies/mine request`);
-    const token = req.user?.token;
-
-    if (!token) {
-      this.logger.error('Authorization token is missing in the request');
-      throw new UnauthorizedException('Authorization token is missing');
-    }
-
-    if (req.user?.role !== UserRole.RESIDENT) {
-      this.logger.error('User does not have resident permissions to perform this action');
-      throw new ForbiddenException('You do not have permission to perform this action');
-    }
+    const token = this.ensureResidentAndGetToken(req);
 
     return this.messageService.replyAsResident(id, body, token);
   }
@@ -171,6 +151,22 @@ export class MessageController {
 
     if (req.user?.role !== UserRole.ADMIN) {
       this.logger.error('User does not have admin permissions to perform this action');
+      throw new ForbiddenException('You do not have permission to perform this action');
+    }
+
+    return token;
+  }
+
+  private ensureResidentAndGetToken(req: any): string {
+    const token = req.user?.token;
+
+    if (!token) {
+      this.logger.error('Authorization token is missing in the request');
+      throw new UnauthorizedException('Authorization token is missing');
+    }
+
+    if (req.user?.role !== UserRole.RESIDENT) {
+      this.logger.error('User does not have resident permissions to perform this action');
       throw new ForbiddenException('You do not have permission to perform this action');
     }
 

--- a/src/api/controllers/message.controller.ts
+++ b/src/api/controllers/message.controller.ts
@@ -60,6 +60,25 @@ export class MessageController {
   }
 
   @UseGuards(JwtAuthGuard)
+  @Get('mine')
+  async getResidentMessages(@Req() req: any, @Query() query: Record<string, unknown>): Promise<MessageListResponseDto> {
+    this.logger.log('Received GET /messages/mine request');
+    const token = req.user?.token;
+
+    if (!token) {
+      this.logger.error('Authorization token is missing in the request');
+      throw new UnauthorizedException('Authorization token is missing');
+    }
+
+    if (req.user?.role !== UserRole.RESIDENT) {
+      this.logger.error('User does not have resident permissions to perform this action');
+      throw new ForbiddenException('You do not have permission to perform this action');
+    }
+
+    return this.messageService.getResidentMessages(token, query);
+  }
+
+  @UseGuards(JwtAuthGuard)
   @Get('unread-count')
   async getUnreadCount(@Req() req: any): Promise<MessageUnreadStateDto> {
     this.logger.log('Received GET /messages/unread-count request');
@@ -94,6 +113,25 @@ export class MessageController {
     const token = this.ensureAdminAndGetToken(req);
 
     return this.messageService.replyAsAdmin(id, body, token);
+  }
+
+  @UseGuards(JwtAuthGuard)
+  @Post(':id/replies/mine')
+  async replyAsResident(@Param('id', new ParseUUIDPipe()) id: string, @Body(new JoiValidationPipe(CreateMessageReplySchema)) body: CreateMessageReplyDto, @Req() req: any) {
+    this.logger.log(`Received POST /messages/${id}/replies/mine request`);
+    const token = req.user?.token;
+
+    if (!token) {
+      this.logger.error('Authorization token is missing in the request');
+      throw new UnauthorizedException('Authorization token is missing');
+    }
+
+    if (req.user?.role !== UserRole.RESIDENT) {
+      this.logger.error('User does not have resident permissions to perform this action');
+      throw new ForbiddenException('You do not have permission to perform this action');
+    }
+
+    return this.messageService.replyAsResident(id, body, token);
   }
 
   @UseGuards(JwtAuthGuard)

--- a/src/api/dto/message.dto.ts
+++ b/src/api/dto/message.dto.ts
@@ -3,6 +3,8 @@ import * as Joi from '@hapi/joi';
 export type ContactMessageCategory = 'suggestion' | 'complaint' | 'question';
 export type ContactMessageStatus = 'unread' | 'read' | 'replied';
 export type MessageEmailDeliveryStatus = 'not_requested' | 'pending' | 'sent' | 'failed' | 'skipped';
+export type MessageReplyOriginRole = 'admin' | 'resident';
+export type MessageReplyOriginChannel = 'in_app' | 'email_inbound';
 export type ContactEmailDeliveryMode = 'in_app_only' | 'in_app_and_email';
 export type ContactEmailReplyToMode = 'resident_email' | 'custom';
 
@@ -48,12 +50,15 @@ export interface MessageReplyDto {
   messageId: string;
   authorUserId: string;
   authorName: string;
+  originRole: MessageReplyOriginRole;
+  originChannel: MessageReplyOriginChannel;
   content: string;
   sendViaEmail: boolean;
   emailDeliveryStatus: MessageEmailDeliveryStatus;
   emailProviderMessageId?: string | null;
   emailSentAt?: string | null;
   emailLastError?: string | null;
+  externalMessageId?: string | null;
   createdAt: string;
   updatedAt: string;
 }

--- a/src/api/services/message.service.ts
+++ b/src/api/services/message.service.ts
@@ -37,6 +37,15 @@ export class MessageService {
     }
   }
 
+  async getResidentMessages(token: string, query: Record<string, unknown>): Promise<MessageListResponseDto> {
+    try {
+      return await this.httpService.get(`${this.apiUrl}/mine`, query, token);
+    } catch (error) {
+      this.logger.error(`Error in getResidentMessages: ${error.message}`);
+      throw error;
+    }
+  }
+
   async getUnreadCount(token: string): Promise<MessageUnreadStateDto> {
     try {
       return await this.httpService.get(`${this.apiUrl}/unread-count`, undefined, token);
@@ -60,6 +69,15 @@ export class MessageService {
       return await this.httpService.post(`${this.apiUrl}/${id}/replies`, body, token);
     } catch (error) {
       this.logger.error(`Error in replyAsAdmin: ${error.message}`);
+      throw error;
+    }
+  }
+
+  async replyAsResident(id: string, body: CreateMessageReplyDto, token: string): Promise<MessageReplyDto> {
+    try {
+      return await this.httpService.post(`${this.apiUrl}/${id}/replies/mine`, body, token);
+    } catch (error) {
+      this.logger.error(`Error in replyAsResident: ${error.message}`);
       throw error;
     }
   }


### PR DESCRIPTION
This pull request adds new resident-specific messaging functionality to the system, allowing residents to view their own messages and reply to them via dedicated endpoints. It also expands the message reply data structure to include more metadata about the origin of replies. The changes include updates to the controller, service, DTOs, and tests.

**Resident messaging endpoints and service logic:**

- Added a new `GET /messages/mine` endpoint in `MessageController` for residents to fetch their own messages, with authentication and role checks. The corresponding `getResidentMessages` method was added to `MessageService` to call the backend API. [[1]](diffhunk://#diff-608097fe113acda1b2ad142d5f3da31f85453d79baa2d9145531398ff4b11ee6R62-R80) [[2]](diffhunk://#diff-ce4e9cebf17d40294c86cedff1aa5a33490fde3c843970a9b6ee6ded47e47c2cR40-R48)
- Added a new `POST /messages/:id/replies/mine` endpoint in `MessageController` for residents to reply to messages, with authentication and role checks. The corresponding `replyAsResident` method was added to `MessageService`. [[1]](diffhunk://#diff-608097fe113acda1b2ad142d5f3da31f85453d79baa2d9145531398ff4b11ee6R118-R136) [[2]](diffhunk://#diff-ce4e9cebf17d40294c86cedff1aa5a33490fde3c843970a9b6ee6ded47e47c2cR76-R84)

**DTO and type enhancements:**

- Expanded the `MessageReplyDto` interface to include `originRole`, `originChannel`, and `externalMessageId` fields, and defined new types `MessageReplyOriginRole` and `MessageReplyOriginChannel` for better tracking of reply origins. [[1]](diffhunk://#diff-055ba855bbbdadf1d6c78f57d40f99523a510b134911b2bdcf79e887d46a38d7R6-R7) [[2]](diffhunk://#diff-055ba855bbbdadf1d6c78f57d40f99523a510b134911b2bdcf79e887d46a38d7R53-R61)

**Test updates:**

- Updated the message controller tests to mock the new resident-specific service methods.…yAsResident methods