### PR TITLE
Add request ID retrieval and JTI to token payload

### DIFF
--- a/src/api/services/user.service.auth-regression.spec.ts
+++ b/src/api/services/user.service.auth-regression.spec.ts
@@ -106,6 +106,7 @@ describe('Phase 5 - BFF auth regression flow', () => {
   };
   const requestContextService = {
     setOrganizationId: jest.fn(),
+    getRequestId: jest.fn(() => 'req-phase5'),
   };
 
   const createContext = (token: string) =>

--- a/src/shared/auth/services/auth.service.ts
+++ b/src/shared/auth/services/auth.service.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import { JwtService } from '@nestjs/jwt';
 import * as bcrypt from 'bcrypt';
+import { randomUUID } from 'crypto';
 
 @Injectable()
 export class AuthService {
@@ -29,6 +30,7 @@ export class AuthService {
     const tokenPayload = {
       name: payload.name,
       sub: payload.id,
+      jti: randomUUID(),
       role: payload.role,
       organizationId: payload.organizationId,
       ...(payload.onboarding ? { onboarding: payload.onboarding } : {}),


### PR DESCRIPTION
This pull request introduces an enhancement to the authentication service by adding a unique JWT ID (`jti`) to the token payload, and includes a minor update to a test mock. The main purpose is to improve traceability and security of issued tokens.

**Authentication Enhancements:**
* Added `jti` (JWT ID) to the JWT token payload in the `AuthService`, using `randomUUID()` to generate a unique identifier for each token. This helps with token revocation and tracking. [[1]](diffhunk://#diff-f1f00011d0a9822432630899c43af8964ffbb65eb9d904a34d4b3663ade5b359R4) [[2]](diffhunk://#diff-f1f00011d0a9822432630899c43af8964ffbb65eb9d904a34d4b3663ade5b359R33)

**Test Improvements:**
* Updated the `requestContextService` mock in the phase 5 BFF auth regression test to include a stubbed `getRequestId` method for improved test coverage.