### PR TITLE
Enhance JwtAuthGuard and SecurityObservabilityService with request context

### DIFF
--- a/src/shared/auth/guards/jwt-auth.guard.spec.ts
+++ b/src/shared/auth/guards/jwt-auth.guard.spec.ts
@@ -219,6 +219,48 @@ describe('BFF JwtAuthGuard - Phase 2 revocation enforcement', () => {
     );
   });
 
+  it('records auth failure with hasSessionCookie=true and hasCookieHeader=true for cookie-auth requests', async () => {
+    revokedTokenRepository.findOne.mockResolvedValue(null);
+    jwtService.verify.mockImplementation(() => {
+      const error = new Error('jwt expired');
+      (error as Error & { name: string }).name = 'TokenExpiredError';
+      throw error;
+    });
+
+    await expect(guard.canActivate(createContext('/users/profile', { useCookie: true }))).rejects.toThrow(UnauthorizedException);
+    expect(securityObservability.recordAuthFailure).toHaveBeenCalledWith(
+      'invalid_or_expired_token',
+      '/users/profile',
+      expect.objectContaining({
+        hasSessionCookie: true,
+        hasCookieHeader: true,
+        hasAuthorizationHeader: false,
+        authSource: 'cookie',
+      }),
+    );
+  });
+
+  it('records auth failure with hasAuthorizationHeader=true for bearer-auth requests', async () => {
+    revokedTokenRepository.findOne.mockResolvedValue(null);
+    jwtService.verify.mockImplementation(() => {
+      const error = new Error('jwt expired');
+      (error as Error & { name: string }).name = 'TokenExpiredError';
+      throw error;
+    });
+
+    await expect(guard.canActivate(createContext('/users/profile', { useCookie: false }))).rejects.toThrow(UnauthorizedException);
+    expect(securityObservability.recordAuthFailure).toHaveBeenCalledWith(
+      'invalid_or_expired_token',
+      '/users/profile',
+      expect.objectContaining({
+        hasAuthorizationHeader: true,
+        hasCookieHeader: false,
+        hasSessionCookie: false,
+        authSource: 'bearer',
+      }),
+    );
+  });
+
   it('returns service unavailable when onboarding profile lookup fails', async () => {
     revokedTokenRepository.findOne.mockResolvedValue(null);
     httpService.get.mockRejectedValue(new Error('upstream timeout'));

--- a/src/shared/auth/guards/jwt-auth.guard.spec.ts
+++ b/src/shared/auth/guards/jwt-auth.guard.spec.ts
@@ -191,6 +191,10 @@ describe('BFF JwtAuthGuard - Phase 2 revocation enforcement', () => {
             'x-request-id': 'req-bot-1',
             origin: 'https://app.example.com',
             'user-agent': 'Read-Aloud Crawler/1.0',
+            'x-organization-slug-hint': 'seuze',
+            'x-user-apartment-hint': '1201',
+            'x-user-block-hint': '2',
+            cookie: 'other_cookie=123',
           },
         }),
       }),
@@ -205,6 +209,12 @@ describe('BFF JwtAuthGuard - Phase 2 revocation enforcement', () => {
         origin: 'https://app.example.com',
         authSource: 'none',
         isBotTraffic: true,
+        organizationSlugHint: 'seuze',
+        apartmentHint: '1201',
+        blockHint: '2',
+        hasAuthorizationHeader: false,
+        hasCookieHeader: true,
+        hasSessionCookie: false,
       }),
     );
   });

--- a/src/shared/auth/guards/jwt-auth.guard.ts
+++ b/src/shared/auth/guards/jwt-auth.guard.ts
@@ -159,11 +159,22 @@ export class JwtAuthGuard implements CanActivate {
     origin: string;
     userAgent: string;
     isBotTraffic: boolean;
+    apartmentHint?: string;
+    blockHint?: string;
+    organizationSlugHint?: string;
+    hasCookieHeader: boolean;
+    hasAuthorizationHeader: boolean;
+    hasSessionCookie: boolean;
   } {
     const headers = request.headers || {};
     const requestIdHeader = headers['x-request-id'];
     const originHeader = headers.origin;
     const userAgentHeader = headers['user-agent'];
+    const organizationSlugHintHeader = headers['x-organization-slug-hint'];
+    const apartmentHintHeader = headers['x-user-apartment-hint'];
+    const blockHintHeader = headers['x-user-block-hint'];
+    const authorizationHeader = headers.authorization;
+    const cookieHeader = headers.cookie;
 
     const requestId =
       (Array.isArray(requestIdHeader) ? requestIdHeader[0] : requestIdHeader)?.toString().trim()
@@ -172,12 +183,26 @@ export class JwtAuthGuard implements CanActivate {
     const origin = (Array.isArray(originHeader) ? originHeader[0] : originHeader)?.toString().trim() || 'missing-origin';
     const userAgent =
       (Array.isArray(userAgentHeader) ? userAgentHeader[0] : userAgentHeader)?.toString().trim() || 'missing-user-agent';
+    const organizationSlugHint =
+      (Array.isArray(organizationSlugHintHeader) ? organizationSlugHintHeader[0] : organizationSlugHintHeader)?.toString().trim() || undefined;
+    const apartmentHint =
+      (Array.isArray(apartmentHintHeader) ? apartmentHintHeader[0] : apartmentHintHeader)?.toString().trim() || undefined;
+    const blockHint =
+      (Array.isArray(blockHintHeader) ? blockHintHeader[0] : blockHintHeader)?.toString().trim() || undefined;
+    const cookieHeaderValue = (Array.isArray(cookieHeader) ? cookieHeader[0] : cookieHeader)?.toString();
+    const hasSessionCookie = Boolean(getAuthTokenFromCookieHeader(cookieHeaderValue));
 
     return {
       requestId,
       origin,
       userAgent,
       isBotTraffic: JwtAuthGuard.BOT_USER_AGENT_PATTERN.test(userAgent),
+      organizationSlugHint,
+      apartmentHint,
+      blockHint,
+      hasCookieHeader: Boolean((Array.isArray(cookieHeader) ? cookieHeader[0] : cookieHeader)?.toString().trim()),
+      hasAuthorizationHeader: Boolean((Array.isArray(authorizationHeader) ? authorizationHeader[0] : authorizationHeader)?.toString().trim()),
+      hasSessionCookie,
     };
   }
 

--- a/src/shared/auth/guards/jwt-auth.guard.ts
+++ b/src/shared/auth/guards/jwt-auth.guard.ts
@@ -62,9 +62,9 @@ export class JwtAuthGuard implements CanActivate {
 
     const request = context.switchToHttp().getRequest();
     const isMutationMethod = ['POST', 'PUT', 'PATCH', 'DELETE'].includes((request.method || '').toUpperCase());
-    const observabilityDetails = this.getAuthFailureDetails(request);
     const headerToken = request.headers.authorization?.split(' ')[1];
     const cookieToken = getAuthTokenFromCookieHeader(request.headers.cookie);
+    const observabilityDetails = this.getAuthFailureDetails(request, cookieToken);
     const token = headerToken || cookieToken;
     const authSource = headerToken ? 'bearer' : cookieToken ? 'cookie' : 'none';
     const isCookieAuthenticated = authSource === 'cookie';
@@ -154,7 +154,7 @@ export class JwtAuthGuard implements CanActivate {
 
   private getAuthFailureDetails(request: {
     headers?: Record<string, unknown>;
-  }): {
+  }, cookieToken?: string | null): {
     requestId: string;
     origin: string;
     userAgent: string;
@@ -189,8 +189,7 @@ export class JwtAuthGuard implements CanActivate {
       (Array.isArray(apartmentHintHeader) ? apartmentHintHeader[0] : apartmentHintHeader)?.toString().trim() || undefined;
     const blockHint =
       (Array.isArray(blockHintHeader) ? blockHintHeader[0] : blockHintHeader)?.toString().trim() || undefined;
-    const cookieHeaderValue = (Array.isArray(cookieHeader) ? cookieHeader[0] : cookieHeader)?.toString();
-    const hasSessionCookie = Boolean(getAuthTokenFromCookieHeader(cookieHeaderValue));
+    const hasSessionCookie = Boolean(cookieToken);
 
     return {
       requestId,

--- a/src/shared/security/security-observability.service.ts
+++ b/src/shared/security/security-observability.service.ts
@@ -30,7 +30,9 @@ export class SecurityObservabilityService {
 
   recordAuthFailure(reason: string, context: string, details?: AuthFailureDetails): void {
     this.counters.authFailures += 1;
-    const requestId = details?.requestId || 'missing-request-id';
+    const requestId = this.sanitizeLogValue(details?.requestId || 'missing-request-id');
+    const sanitizedContext = this.sanitizeLogValue(context);
+    const sanitizedReason = this.sanitizeLogValue(reason);
     const origin = this.sanitizeLogValue(details?.origin || 'missing-origin');
     const userAgent = this.sanitizeLogValue(details?.userAgent || 'missing-user-agent');
     const authSource = details?.authSource || 'none';
@@ -42,7 +44,7 @@ export class SecurityObservabilityService {
     const hasAuthorizationHeader = details?.hasAuthorizationHeader ? 'true' : 'false';
     const hasSessionCookie = details?.hasSessionCookie ? 'true' : 'false';
     this.logger.warn(
-      `event=auth_failure requestId=${requestId} context=${context} reason="${reason}" authSource=${authSource} isBotTraffic=${isBotTraffic} hasAuthorizationHeader=${hasAuthorizationHeader} hasCookieHeader=${hasCookieHeader} hasSessionCookie=${hasSessionCookie} organizationSlugHint="${organizationSlugHint}" apartmentHint="${apartmentHint}" blockHint="${blockHint}" origin="${origin}" userAgent="${userAgent}" count=${this.counters.authFailures}`,
+      `event=auth_failure requestId=${requestId} context=${sanitizedContext} reason="${sanitizedReason}" authSource=${authSource} isBotTraffic=${isBotTraffic} hasAuthorizationHeader=${hasAuthorizationHeader} hasCookieHeader=${hasCookieHeader} hasSessionCookie=${hasSessionCookie} organizationSlugHint="${organizationSlugHint}" apartmentHint="${apartmentHint}" blockHint="${blockHint}" origin="${origin}" userAgent="${userAgent}" count=${this.counters.authFailures}`,
     );
   }
 

--- a/src/shared/security/security-observability.service.ts
+++ b/src/shared/security/security-observability.service.ts
@@ -6,6 +6,12 @@ export interface AuthFailureDetails {
   userAgent?: string;
   authSource?: 'cookie' | 'bearer' | 'none';
   isBotTraffic?: boolean;
+  apartmentHint?: string;
+  blockHint?: string;
+  organizationSlugHint?: string;
+  hasCookieHeader?: boolean;
+  hasAuthorizationHeader?: boolean;
+  hasSessionCookie?: boolean;
 }
 
 @Injectable()
@@ -29,8 +35,14 @@ export class SecurityObservabilityService {
     const userAgent = this.sanitizeLogValue(details?.userAgent || 'missing-user-agent');
     const authSource = details?.authSource || 'none';
     const isBotTraffic = details?.isBotTraffic ? 'true' : 'false';
+    const apartmentHint = this.sanitizeLogValue(details?.apartmentHint || 'missing-apartment-hint');
+    const blockHint = this.sanitizeLogValue(details?.blockHint || 'missing-block-hint');
+    const organizationSlugHint = this.sanitizeLogValue(details?.organizationSlugHint || 'missing-organization-slug-hint');
+    const hasCookieHeader = details?.hasCookieHeader ? 'true' : 'false';
+    const hasAuthorizationHeader = details?.hasAuthorizationHeader ? 'true' : 'false';
+    const hasSessionCookie = details?.hasSessionCookie ? 'true' : 'false';
     this.logger.warn(
-      `event=auth_failure requestId=${requestId} context=${context} reason="${reason}" authSource=${authSource} isBotTraffic=${isBotTraffic} origin="${origin}" userAgent="${userAgent}" count=${this.counters.authFailures}`,
+      `event=auth_failure requestId=${requestId} context=${context} reason="${reason}" authSource=${authSource} isBotTraffic=${isBotTraffic} hasAuthorizationHeader=${hasAuthorizationHeader} hasCookieHeader=${hasCookieHeader} hasSessionCookie=${hasSessionCookie} organizationSlugHint="${organizationSlugHint}" apartmentHint="${apartmentHint}" blockHint="${blockHint}" origin="${origin}" userAgent="${userAgent}" count=${this.counters.authFailures}`,
     );
   }
 


### PR DESCRIPTION
- [x] Understand the three review comments
- [x] Fix 1 (jwt-auth.guard.ts): Avoid calling `getAuthTokenFromCookieHeader` twice — compute `cookieToken` before calling `getAuthFailureDetails` and pass it in; `hasSessionCookie = Boolean(cookieToken)` reuses the already-computed value
- [x] Fix 2 (security-observability.service.ts): Sanitize `requestId`, `context`, and `reason` via `sanitizeLogValue` before logging to prevent log injection from client-controlled values
- [x] Fix 3 (jwt-auth.guard.spec.ts): Add two new tests covering `true` paths for `hasSessionCookie`/`hasCookieHeader`/`hasAuthorizationHeader` in auth failure context
- [x] Run tests — all 55 pass
- [ ] Final validation via parallel_validation