### PR TITLE
Enhance getAllUsers method to support query parameters

### DIFF
--- a/src/api/controllers/user.controller.spec.ts
+++ b/src/api/controllers/user.controller.spec.ts
@@ -229,6 +229,35 @@ describe('UserController', () => {
     ).rejects.toThrow(BadRequestException);
   });
 
+  it('forwards users listing query params to service', async () => {
+    service.getAllUsers.mockResolvedValue({
+      data: [],
+      total: 0,
+      page: 1,
+      lastPage: 1,
+    } as any);
+
+    await expect(
+      controller.getAllUsers(
+        { user: { token: 'jwt-token' } } as any,
+        { q: 'alice', page: '2', limit: '10', sort: 'name', order: 'ASC' },
+      ),
+    ).resolves.toEqual({
+      data: [],
+      total: 0,
+      page: 1,
+      lastPage: 1,
+    });
+
+    expect(service.getAllUsers).toHaveBeenCalledWith('jwt-token', {
+      q: 'alice',
+      page: '2',
+      limit: '10',
+      sort: 'name',
+      order: 'ASC',
+    });
+  });
+
   it('proxies first-access tour completion endpoint', async () => {
     service.completeFirstAccessTour.mockResolvedValue({
       message: 'First access tour marked as completed',

--- a/src/api/controllers/user.controller.ts
+++ b/src/api/controllers/user.controller.ts
@@ -1,4 +1,4 @@
-import { BadRequestException, Controller, Post, Body, Logger, Get, Put, Delete, Param, Req, UseGuards, UnauthorizedException, Res, ForbiddenException } from '@nestjs/common';
+import { BadRequestException, Controller, Post, Body, Logger, Get, Put, Delete, Param, Req, UseGuards, UnauthorizedException, Res, ForbiddenException, Query } from '@nestjs/common';
 import { CreateUserDto, CreateUserSchema } from '../dto/create-user.dto';
 import { LoginUserDto, LoginUserSchema } from '../dto/login-user.dto';
 import { UpdateUserDto, UpdateUserSchema } from '../dto/update-user.dto';
@@ -92,7 +92,7 @@ export class UserController {
 
   @UseGuards(JwtAuthGuard)
   @Get()
-  async getAllUsers(@Req() req: any) {
+  async getAllUsers(@Req() req: any, @Query() query: Record<string, unknown>) {
     this.logger.log('Entering UserController.getAllUsers');
 
     const token = req.user?.token;
@@ -103,7 +103,7 @@ export class UserController {
     }
 
     this.logger.log('Calling UserService to fetch all users');
-    return this.userService.getAllUsers(token);
+    return this.userService.getAllUsers(token, query);
   }
 
   @UseGuards(JwtAuthGuard)

--- a/src/api/services/user.service.spec.ts
+++ b/src/api/services/user.service.spec.ts
@@ -20,6 +20,7 @@ describe('UserService - BFF-owned logout revocation', () => {
   };
   const httpService = {
     post: jest.fn(),
+    get: jest.fn(),
   };
 
   let service: UserService;
@@ -296,5 +297,15 @@ describe('UserService - BFF-owned logout revocation', () => {
     expect(httpService.post).toHaveBeenCalledWith('users/email/change/confirm', {
       token: 'email-change-token',
     }, 'jwt-token');
+  });
+
+  it('forwards users listing query params to API', async () => {
+    httpService.get.mockResolvedValue({ data: [], total: 0, page: 1, lastPage: 1 });
+
+    await expect(
+      service.getAllUsers('jwt-token', { q: 'alice', page: '1', limit: '10' }),
+    ).resolves.toEqual({ data: [], total: 0, page: 1, lastPage: 1 });
+
+    expect(httpService.get).toHaveBeenCalledWith('users', { q: 'alice', page: '1', limit: '10' }, 'jwt-token');
   });
 });

--- a/src/api/services/user.service.ts
+++ b/src/api/services/user.service.ts
@@ -151,11 +151,11 @@ export class UserService {
     };
   }
 
-  async getAllUsers(token: string) {
+  async getAllUsers(token: string, query?: Record<string, unknown>) {
     this.logger.log('Entering UserService.getAllUsers');
 
     this.logger.log('Redirecting GET all users request to API');
-    return this.httpService.get('users', undefined, token);
+    return this.httpService.get('users', query, token);
   }
 
   async updateProfile(updateData: UpdateUserDto, token: string) {


### PR DESCRIPTION
This pull request improves the handling of user listing query parameters in both the `UserController` and `UserService`. The main change is to ensure that query parameters such as search, pagination, and sorting are properly forwarded from the controller to the service and then to the underlying API, allowing for more flexible user queries. Related tests have been added to validate this behavior.

**User listing query parameter forwarding:**

* [`src/api/controllers/user.controller.ts`](diffhunk://#diff-c82e3f32fe08c263da2ef976c674bfdd444f217a493f77e0e5d475cd4fc5c27eL95-R95): Updated the `getAllUsers` endpoint to accept and forward query parameters to the `UserService.getAllUsers` method. [[1]](diffhunk://#diff-c82e3f32fe08c263da2ef976c674bfdd444f217a493f77e0e5d475cd4fc5c27eL95-R95) [[2]](diffhunk://#diff-c82e3f32fe08c263da2ef976c674bfdd444f217a493f77e0e5d475cd4fc5c27eL106-R106)
* [`src/api/services/user.service.ts`](diffhunk://#diff-eaf6d32e985a7700a3fc3ff8324641c4b76ee760fdb4767ed6259a868f442ec9L154-R158): Modified the `getAllUsers` method to accept an optional `query` parameter and forward it to the underlying HTTP service.

**Testing improvements:**

* [`src/api/controllers/user.controller.spec.ts`](diffhunk://#diff-1af8ee96aa4c82d9bcbe45a4d7fab20013f015d28496e0c8ae013bd3a83081d6R232-R260): Added a test to verify that the controller forwards query parameters correctly to the service.
* [`src/api/services/user.service.spec.ts`](diffhunk://#diff-ff6cb1089588575d29c0ab260d873bcf3b4fb8e0e1985a47d027c816dbdb6a89R301-R310): Added a test to ensure the service forwards query parameters to the API layer.
* [`src/api/services/user.service.spec.ts`](diffhunk://#diff-ff6cb1089588575d29c0ab260d873bcf3b4fb8e0e1985a47d027c816dbdb6a89R23): Mocked the `get` method on the HTTP service to support the new tests.

**Dependency updates:**

* [`src/api/controllers/user.controller.ts`](diffhunk://#diff-c82e3f32fe08c263da2ef976c674bfdd444f217a493f77e0e5d475cd4fc5c27eL1-R1): Added the `Query` decorator import to support query parameter extraction.