### PR TITLE
Implement onboarding functionality in WhatsApp settings

### DIFF
--- a/src/api/controllers/whatsapp-settings.controller.spec.ts
+++ b/src/api/controllers/whatsapp-settings.controller.spec.ts
@@ -1,0 +1,84 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ForbiddenException } from '@nestjs/common';
+import { JwtAuthGuard } from '../../shared/auth/guards/jwt-auth.guard';
+import { UserRole } from '../entities/user.entity';
+import { WhatsappSettingsController } from './whatsapp-settings.controller';
+import { WhatsappSettingsService } from '../services/whatsapp-settings.service';
+
+describe('WhatsappSettingsController', () => {
+  let controller: WhatsappSettingsController;
+  let service: jest.Mocked<WhatsappSettingsService>;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [WhatsappSettingsController],
+      providers: [
+        {
+          provide: WhatsappSettingsService,
+          useValue: {
+            getSettings: jest.fn(),
+            bootstrapLegacy: jest.fn(),
+            updateSettings: jest.fn(),
+            testConnection: jest.fn(),
+            startOnboarding: jest.fn(),
+            getOnboardingStatus: jest.fn(),
+            refreshOnboardingQr: jest.fn(),
+            disconnectOnboarding: jest.fn(),
+            getGroups: jest.fn(),
+            getBindings: jest.fn(),
+            upsertBinding: jest.fn(),
+          },
+        },
+      ],
+    })
+      .overrideGuard(JwtAuthGuard)
+      .useValue({ canActivate: () => true })
+      .compile();
+
+    controller = module.get<WhatsappSettingsController>(WhatsappSettingsController);
+    service = module.get(WhatsappSettingsService) as jest.Mocked<WhatsappSettingsService>;
+  });
+
+  it('proxies onboarding start for admins', async () => {
+    service.startOnboarding.mockResolvedValue({ state: 'qr_ready' } as any);
+
+    await expect(controller.startOnboarding({ user: { role: UserRole.ADMIN, token: 'jwt-token' } } as any)).resolves.toEqual({
+      state: 'qr_ready',
+    });
+    expect(service.startOnboarding).toHaveBeenCalledWith('jwt-token');
+  });
+
+  it('proxies onboarding status for admins', async () => {
+    service.getOnboardingStatus.mockResolvedValue({ state: 'connecting' } as any);
+
+    await expect(
+      controller.getOnboardingStatus({ forceQr: true }, { user: { role: UserRole.ADMIN, token: 'jwt-token' } } as any),
+    ).resolves.toEqual({ state: 'connecting' });
+    expect(service.getOnboardingStatus).toHaveBeenCalledWith({ forceQr: true }, 'jwt-token');
+  });
+
+  it('proxies onboarding refresh qr for admins', async () => {
+    service.refreshOnboardingQr.mockResolvedValue({ state: 'qr_ready' } as any);
+
+    await expect(controller.refreshOnboardingQr({ user: { role: UserRole.ADMIN, token: 'jwt-token' } } as any)).resolves.toEqual({
+      state: 'qr_ready',
+    });
+    expect(service.refreshOnboardingQr).toHaveBeenCalledWith('jwt-token');
+  });
+
+  it('proxies onboarding disconnect for admins', async () => {
+    service.disconnectOnboarding.mockResolvedValue({ ok: true });
+
+    await expect(
+      controller.disconnectOnboarding({ user: { role: UserRole.ADMIN, token: 'jwt-token' } } as any),
+    ).resolves.toEqual({ ok: true });
+    expect(service.disconnectOnboarding).toHaveBeenCalledWith('jwt-token');
+  });
+
+  it('blocks onboarding mutations for non-admin users', async () => {
+    await expect(
+      controller.startOnboarding({ user: { role: UserRole.RESIDENT, token: 'jwt-token' } } as any),
+    ).rejects.toThrow(ForbiddenException);
+    expect(service.startOnboarding).not.toHaveBeenCalled();
+  });
+});

--- a/src/api/controllers/whatsapp-settings.controller.spec.ts
+++ b/src/api/controllers/whatsapp-settings.controller.spec.ts
@@ -81,4 +81,28 @@ describe('WhatsappSettingsController', () => {
     ).rejects.toThrow(ForbiddenException);
     expect(service.startOnboarding).not.toHaveBeenCalled();
   });
+
+  it('blocks onboarding status for non-admin users', async () => {
+    await expect(
+      controller.getOnboardingStatus(
+        { forceQr: true },
+        { user: { role: UserRole.RESIDENT, token: 'jwt-token' } } as any,
+      ),
+    ).rejects.toThrow(ForbiddenException);
+    expect(service.getOnboardingStatus).not.toHaveBeenCalled();
+  });
+
+  it('blocks onboarding refresh qr for non-admin users', async () => {
+    await expect(
+      controller.refreshOnboardingQr({ user: { role: UserRole.RESIDENT, token: 'jwt-token' } } as any),
+    ).rejects.toThrow(ForbiddenException);
+    expect(service.refreshOnboardingQr).not.toHaveBeenCalled();
+  });
+
+  it('blocks onboarding disconnect for non-admin users', async () => {
+    await expect(
+      controller.disconnectOnboarding({ user: { role: UserRole.RESIDENT, token: 'jwt-token' } } as any),
+    ).rejects.toThrow(ForbiddenException);
+    expect(service.disconnectOnboarding).not.toHaveBeenCalled();
+  });
 });

--- a/src/api/controllers/whatsapp-settings.controller.ts
+++ b/src/api/controllers/whatsapp-settings.controller.ts
@@ -8,6 +8,7 @@ import {
   Param,
   Post,
   Put,
+  Query,
   Req,
   UnauthorizedException,
   UseGuards,
@@ -17,6 +18,8 @@ import { JoiValidationPipe } from '../../shared/pipes/joi-validation.pipe';
 import { UserRole } from '../entities/user.entity';
 import { WhatsappSettingsService } from '../services/whatsapp-settings.service';
 import {
+  OnboardingStatusQueryDto,
+  OnboardingStatusQuerySchema,
   TestWhatsappConnectionSchema,
   TestWhatsappConnectionDto,
   UpdateWhatsappSettingsSchema,
@@ -68,6 +71,41 @@ export class WhatsappSettingsController {
     this.logger.log('Received POST /whatsapp/settings/test-connection request');
     const token = this.ensureAdminAndGetToken(req);
     return this.whatsappSettingsService.testConnection(body, token);
+  }
+
+  @UseGuards(JwtAuthGuard)
+  @Post('onboarding/start')
+  async startOnboarding(@Req() req: any) {
+    this.logger.log('Received POST /whatsapp/settings/onboarding/start request');
+    const token = this.ensureAdminAndGetToken(req);
+    return this.whatsappSettingsService.startOnboarding(token);
+  }
+
+  @UseGuards(JwtAuthGuard)
+  @Get('onboarding/status')
+  async getOnboardingStatus(
+    @Query(new JoiValidationPipe(OnboardingStatusQuerySchema)) query: OnboardingStatusQueryDto,
+    @Req() req: any,
+  ) {
+    this.logger.log('Received GET /whatsapp/settings/onboarding/status request');
+    const token = this.ensureAdminAndGetToken(req);
+    return this.whatsappSettingsService.getOnboardingStatus(query, token);
+  }
+
+  @UseGuards(JwtAuthGuard)
+  @Post('onboarding/refresh-qr')
+  async refreshOnboardingQr(@Req() req: any) {
+    this.logger.log('Received POST /whatsapp/settings/onboarding/refresh-qr request');
+    const token = this.ensureAdminAndGetToken(req);
+    return this.whatsappSettingsService.refreshOnboardingQr(token);
+  }
+
+  @UseGuards(JwtAuthGuard)
+  @Post('onboarding/disconnect')
+  async disconnectOnboarding(@Req() req: any) {
+    this.logger.log('Received POST /whatsapp/settings/onboarding/disconnect request');
+    const token = this.ensureAdminAndGetToken(req);
+    return this.whatsappSettingsService.disconnectOnboarding(token);
   }
 
   @UseGuards(JwtAuthGuard)

--- a/src/api/dto/whatsapp-settings.dto.ts
+++ b/src/api/dto/whatsapp-settings.dto.ts
@@ -19,6 +19,10 @@ export const UpsertWhatsappGroupBindingSchema = Joi.object({
   groupName: Joi.string().trim().max(180).allow('', null).optional(),
 });
 
+export const OnboardingStatusQuerySchema = Joi.object({
+  forceQr: Joi.boolean().optional(),
+});
+
 export interface UpdateWhatsappSettingsDto {
   baseUrl: string;
   instanceName: string;
@@ -36,6 +40,28 @@ export interface TestWhatsappConnectionDto {
 export interface UpsertWhatsappGroupBindingDto {
   groupJid: string;
   groupName?: string | null;
+}
+
+export interface OnboardingStatusQueryDto {
+  forceQr?: boolean;
+}
+
+export type WhatsappOnboardingState =
+  | 'creating_instance'
+  | 'qr_ready'
+  | 'connecting'
+  | 'group_selection'
+  | 'active'
+  | 'failed';
+
+export interface WhatsappOnboardingStatusDto {
+  state: WhatsappOnboardingState;
+  status: 'connected' | 'disconnected';
+  instanceName: string;
+  qrCodeBase64: string | null;
+  ttlSeconds: number | null;
+  statusEndpoint: string;
+  maskedWhatsappNumber: string | null;
 }
 
 export interface WhatsappGroupOptionDto {

--- a/src/api/services/whatsapp-settings.service.spec.ts
+++ b/src/api/services/whatsapp-settings.service.spec.ts
@@ -1,0 +1,52 @@
+import { WhatsappSettingsService } from './whatsapp-settings.service';
+
+describe('WhatsappSettingsService', () => {
+  const httpService = {
+    get: jest.fn(),
+    post: jest.fn(),
+    put: jest.fn(),
+  };
+
+  let service: WhatsappSettingsService;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    service = new WhatsappSettingsService(httpService as any);
+  });
+
+  it('proxies start onboarding to API', async () => {
+    httpService.post.mockResolvedValue({ state: 'qr_ready' });
+
+    await service.startOnboarding('jwt-token');
+
+    expect(httpService.post).toHaveBeenCalledWith('whatsapp/settings/onboarding/start', {}, 'jwt-token');
+  });
+
+  it('proxies onboarding status query to API', async () => {
+    httpService.get.mockResolvedValue({ state: 'connecting' });
+
+    await service.getOnboardingStatus({ forceQr: true }, 'jwt-token');
+
+    expect(httpService.get).toHaveBeenCalledWith(
+      'whatsapp/settings/onboarding/status',
+      { forceQr: true },
+      'jwt-token',
+    );
+  });
+
+  it('proxies refresh qr to API', async () => {
+    httpService.post.mockResolvedValue({ state: 'qr_ready' });
+
+    await service.refreshOnboardingQr('jwt-token');
+
+    expect(httpService.post).toHaveBeenCalledWith('whatsapp/settings/onboarding/refresh-qr', {}, 'jwt-token');
+  });
+
+  it('proxies onboarding disconnect to API', async () => {
+    httpService.post.mockResolvedValue({ ok: true });
+
+    await service.disconnectOnboarding('jwt-token');
+
+    expect(httpService.post).toHaveBeenCalledWith('whatsapp/settings/onboarding/disconnect', {}, 'jwt-token');
+  });
+});

--- a/src/api/services/whatsapp-settings.service.ts
+++ b/src/api/services/whatsapp-settings.service.ts
@@ -2,11 +2,13 @@ import { Injectable } from '@nestjs/common';
 import { HttpServiceWrapper } from '../../shared/http/http.service';
 import { WinstonLoggerService } from '../../shared/logger/winston-logger.service';
 import {
+  OnboardingStatusQueryDto,
   TestWhatsappConnectionDto,
   UpdateWhatsappSettingsDto,
   UpsertWhatsappGroupBindingDto,
   WhatsappGroupBindingDto,
   WhatsappGroupOptionDto,
+  WhatsappOnboardingStatusDto,
   WhatsappSettingsViewDto,
 } from '../dto/whatsapp-settings.dto';
 
@@ -49,6 +51,42 @@ export class WhatsappSettingsService {
       return await this.httpService.post(`${this.apiUrl}/test-connection`, body, token);
     } catch (error) {
       this.logger.error(`Error in testConnection: ${error.message}`);
+      throw error;
+    }
+  }
+
+  async startOnboarding(token: string): Promise<WhatsappOnboardingStatusDto> {
+    try {
+      return await this.httpService.post(`${this.apiUrl}/onboarding/start`, {}, token);
+    } catch (error) {
+      this.logger.error(`Error in startOnboarding: ${error.message}`);
+      throw error;
+    }
+  }
+
+  async getOnboardingStatus(query: OnboardingStatusQueryDto, token: string): Promise<WhatsappOnboardingStatusDto> {
+    try {
+      return await this.httpService.get(`${this.apiUrl}/onboarding/status`, query, token);
+    } catch (error) {
+      this.logger.error(`Error in getOnboardingStatus: ${error.message}`);
+      throw error;
+    }
+  }
+
+  async refreshOnboardingQr(token: string): Promise<WhatsappOnboardingStatusDto> {
+    try {
+      return await this.httpService.post(`${this.apiUrl}/onboarding/refresh-qr`, {}, token);
+    } catch (error) {
+      this.logger.error(`Error in refreshOnboardingQr: ${error.message}`);
+      throw error;
+    }
+  }
+
+  async disconnectOnboarding(token: string): Promise<{ ok: true }> {
+    try {
+      return await this.httpService.post(`${this.apiUrl}/onboarding/disconnect`, {}, token);
+    } catch (error) {
+      this.logger.error(`Error in disconnectOnboarding: ${error.message}`);
       throw error;
     }
   }

--- a/src/api/services/whatsapp-settings.service.ts
+++ b/src/api/services/whatsapp-settings.service.ts
@@ -82,7 +82,7 @@ export class WhatsappSettingsService {
     }
   }
 
-  async disconnectOnboarding(token: string): Promise<{ ok: true }> {
+  async disconnectOnboarding(token: string): Promise<{ ok: boolean }> {
     try {
       return await this.httpService.post(`${this.apiUrl}/onboarding/disconnect`, {}, token);
     } catch (error) {


### PR DESCRIPTION
This pull request adds support for managing WhatsApp onboarding flows via the API, including starting onboarding, checking status, refreshing the QR code, and disconnecting onboarding. It introduces new endpoints, DTOs, validation schemas, and corresponding service methods, along with comprehensive tests for both the controller and service layers.

**WhatsApp Onboarding API Enhancements**

*New Endpoints and Controller Methods:*
- Added endpoints to `WhatsappSettingsController` for onboarding start, status, QR refresh, and disconnect, all protected by the `JwtAuthGuard` and restricted to admin users. Each endpoint logs its invocation and proxies the request to the service layer.

*DTOs and Validation:*
- Introduced `OnboardingStatusQueryDto`, `OnboardingStatusQuerySchema`, `WhatsappOnboardingStatusDto`, and related types to define and validate onboarding-related data structures and query parameters. [[1]](diffhunk://#diff-a50f6e5e6d16ea97add1ab428c33de69f6a7c359ece7c2a0fb53c01397a2878fR22-R25) [[2]](diffhunk://#diff-a50f6e5e6d16ea97add1ab428c33de69f6a7c359ece7c2a0fb53c01397a2878fR45-R66)
- Updated controller imports to include new DTOs and validation schema.

*Service Layer Additions:*
- Implemented `startOnboarding`, `getOnboardingStatus`, `refreshOnboardingQr`, and `disconnectOnboarding` methods in `WhatsappSettingsService` to interact with the backend API for onboarding operations, with error handling and logging.
- Updated service imports to include new DTOs.

*Testing:*
- Added unit tests for the new controller endpoints in `whatsapp-settings.controller.spec.ts`, verifying correct behavior for admin and non-admin users.
- Added unit tests for the new service methods in `whatsapp-settings.service.spec.ts`, ensuring correct proxying of requests to the backend API.